### PR TITLE
fix: kakao navi

### DIFF
--- a/app/src/main/kotlin/me/zipi/navitotesla/receiver/NotificationListener.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/receiver/NotificationListener.kt
@@ -43,17 +43,12 @@ class NotificationListener : NotificationListenerService() {
     override fun onNotificationPosted(sbn: StatusBarNotification) {
         CoroutineScope(Dispatchers.Main).launch {
             super.onNotificationPosted(sbn)
-            if (PoiFinderFactory.isNaviSupport(sbn.packageName) && sbn.postTime - lastNotificationPosted > 2500) {
-                val bundle = Bundle()
-                bundle.putString(FirebaseAnalytics.Param.SCREEN_NAME, "NotificationListener")
-                bundle.putString(FirebaseAnalytics.Param.SCREEN_CLASS, "NotificationListener")
-                AnalysisUtil.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, bundle)
-                AnalysisUtil.setCustomKey("packageName", sbn.packageName)
-                lastNotificationPosted = sbn.postTime
+            if (PoiFinderFactory.isNaviSupport(sbn.packageName)) {
                 val extras = sbn.notification.extras
                 val title = extras.getString(Notification.EXTRA_TITLE) ?: ""
                 val text = extras.getString(Notification.EXTRA_TEXT) ?: ""
                 val subText = extras.getString(Notification.EXTRA_SUB_TEXT) ?: ""
+                val bigText = extras.getCharSequence(Notification.EXTRA_BIG_TEXT)?.toString() ?: ""
 
                 Log.i(
                     this.javaClass.name,
@@ -63,8 +58,15 @@ class NotificationListener : NotificationListenerService() {
                         " postTime: " + sbn.postTime +
                         " title: " + title +
                         " text : " + text +
-                        " subText: " + subText,
+                        " subText: " + subText +
+                        " bigText: " + bigText,
                 )
+
+                val bundle = Bundle()
+                bundle.putString(FirebaseAnalytics.Param.SCREEN_NAME, "NotificationListener")
+                bundle.putString(FirebaseAnalytics.Param.SCREEN_CLASS, "NotificationListener")
+                AnalysisUtil.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, bundle)
+                AnalysisUtil.setCustomKey("packageName", sbn.packageName)
                 ShareWorker.startShare(applicationContext, sbn.packageName, title, text)
                 NaviToTeslaAccessibilityService.notifyIfAvailable(
                     applicationContext,
@@ -77,9 +79,5 @@ class NotificationListener : NotificationListenerService() {
                 AnalysisUtil.logEvent("notification_received", param)
             }
         }
-    }
-
-    companion object {
-        private var lastNotificationPosted = System.currentTimeMillis()
     }
 }

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/KakaoPoiFinder.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/KakaoPoiFinder.kt
@@ -51,7 +51,7 @@ class KakaoPoiFinder : PoiFinder {
     override fun isIgnore(
         notificationTitle: String,
         notificationText: String,
-    ): Boolean = notificationTitle != "길안내 주행 중"
+    ): Boolean = notificationTitle != "길안내 주행 중" || !notificationText.contains("목적지 : ")
 
     companion object {
         private val kakaoMapApi =


### PR DESCRIPTION
카카오 내비 알림 수신 방식변화로 인한 전송 실패 해결
- 알림이 두번 수신되고, 두번째에 목적지가 나옴
- 첫번째 이후 2.5초 내에 수신은 무시하라고 하였으나 이로 인해 카카오 내비 안되는 버그