### PR TITLE
fix: 네이버내비 출입구 버그 수정

### DIFF
--- a/app/src/main/kotlin/me/zipi/navitotesla/service/NaviToTeslaAccessibilityService.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/NaviToTeslaAccessibilityService.kt
@@ -6,6 +6,7 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
+import android.graphics.Rect
 import android.os.Build
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityManager
@@ -22,20 +23,30 @@ import me.zipi.navitotesla.util.AppUpdaterUtil
 import me.zipi.navitotesla.util.PreferencesUtil
 
 class NaviToTeslaAccessibilityService : AccessibilityService() {
+    @Volatile private var lastCaptureAt = 0L
+
     override fun onAccessibilityEvent(event: AccessibilityEvent) {
         try {
-            if (event.eventType != AccessibilityEvent.TYPE_VIEW_CLICKED && event.eventType != AccessibilityEvent.TYPE_VIEW_SELECTED) {
+            if (event.eventType != AccessibilityEvent.TYPE_VIEW_CLICKED &&
+                event.eventType != AccessibilityEvent.TYPE_VIEW_SELECTED
+            ) {
                 return
             }
-            if (PoiFinderFactory.isNaverMap(event.packageName.toString())) {
-                val window = rootInActiveWindow ?: return
-                // route_search_bar: Compose 기반 경로 검색 바 (출발지, 목적지 순서로 TextView 포함)
-                val searchBarNodes = window.findAccessibilityNodeInfosByViewId("com.nhn.android.nmap:id/route_search_bar")
-                searchBarNodes
-                    ?.flatMap { collectTexts(it) }
-                    ?.lastOrNull()
-                    ?.let { NaverPoiFinder.addDestination(it) }
-            }
+            if (!PoiFinderFactory.isNaverMap(event.packageName?.toString() ?: return)) return
+
+            val viewId = event.source?.viewIdResourceName
+            if (viewId != null && viewId !in NAVER_CAPTURE_TRIGGER_HINT_IDS) return
+
+            val now = System.currentTimeMillis()
+            if (now - lastCaptureAt < CAPTURE_DEBOUNCE_MS) return
+            lastCaptureAt = now
+
+            val window = rootInActiveWindow ?: return
+            val texts =
+                window
+                    .findAccessibilityNodeInfosByViewId("com.nhn.android.nmap:id/route_search_bar")
+                    ?.flatMap { collectTextsWithBounds(it) } ?: emptyList()
+            destinationFrom(texts)?.let { NaverPoiFinder.addDestination(it) }
         } catch (e: Exception) {
             AnalysisUtil.warn("accessibility error: " + e.message)
             AnalysisUtil.recordException(e)
@@ -44,16 +55,40 @@ class NaviToTeslaAccessibilityService : AccessibilityService() {
 
     override fun onInterrupt() {}
 
-    private fun collectTexts(node: AccessibilityNodeInfo): List<String> {
-        val result = mutableListOf<String>()
-        node.text?.toString()?.takeIf { it.isNotBlank() }?.let { result.add(it) }
+    private fun collectTextsWithBounds(node: AccessibilityNodeInfo): List<Pair<String, Rect>> {
+        if (!node.isVisibleToUser) return emptyList()
+        val result = mutableListOf<Pair<String, Rect>>()
+        node.text?.toString()?.takeIf { it.isNotBlank() }?.let {
+            val rect = Rect()
+            node.getBoundsInScreen(rect)
+            result.add(it to rect)
+        }
         for (i in 0 until node.childCount) {
-            node.getChild(i)?.let { result.addAll(collectTexts(it)) }
+            node.getChild(i)?.let { result.addAll(collectTextsWithBounds(it)) }
         }
         return result
     }
 
+    private fun destinationFrom(texts: List<Pair<String, Rect>>): String? {
+        val anchorY = texts.firstOrNull { it.first == ENTRANCE_CHANGE_LABEL }?.second?.top
+        val mainRows = if (anchorY != null) texts.filter { it.second.top < anchorY } else texts
+        return mainRows.lastOrNull()?.first
+    }
+
     companion object {
+        private const val CAPTURE_DEBOUNCE_MS = 200L
+
+        private const val ENTRANCE_CHANGE_LABEL = "출입구 변경"
+
+        private val NAVER_CAPTURE_TRIGGER_HINT_IDS =
+            setOf(
+                "com.nhn.android.nmap:id/v_start_guidance",
+                "com.nhn.android.nmap:id/btn_route_start",
+                "com.nhn.android.nmap:id/btn_route_goal",
+                "com.nhn.android.nmap:id/btn_route",
+                "com.nhn.android.nmap:id/route_search_bar",
+            )
+
         private var lastNotifyAppVersion: String? = null
 
         /**

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/NaverPoiFinder.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/NaverPoiFinder.kt
@@ -93,7 +93,7 @@ class NaverPoiFinder : PoiFinder {
         // 안내가 시작될 경우 도착지를 이용하여 전송한다. 목적지가 입력된지 특정 시간 내에만 동작한다.
         return notificationText != "내비게이션 - 안내 중" ||
             destination.isNullOrEmpty() ||
-            System.currentTimeMillis() - savedTime > 3 * 60 * 1000
+            System.currentTimeMillis() - savedTime > DESTINATION_TTL_MS
     }
 
     companion object {
@@ -151,17 +151,27 @@ class NaverPoiFinder : PoiFinder {
                 .create(NaverFusionSearchApi::class.java)
 
         // 접근성 도구로 판단한 목적지 임시 저장
-        private var destination: String? = null
-        private var savedTime = System.currentTimeMillis()
+        @Volatile private var destination: String? = null
+
+        @Volatile private var savedTime = System.currentTimeMillis()
+
+        private val PLACEHOLDER_TEXTS =
+            setOf("도착지 입력", "출발지 입력", "경유지 입력")
+
+        private const val DESTINATION_TTL_MS = 60_000L
 
         fun addDestination(dest: String) {
-            // 접근성 도구로 도착지가 비어있을 경우 임시 변수 초기화
-            if (dest.trim().equals("도착지 입력", ignoreCase = true)) {
-                destination = ""
+            val cleaned = dest.trim()
+            if (cleaned.isEmpty()) return
+            if (PLACEHOLDER_TEXTS.any { it.equals(cleaned, ignoreCase = true) }) {
+                destination = null
                 return
             }
-            // 도착지가 입력
-            destination = dest.trim()
+            if (cleaned == destination) {
+                savedTime = System.currentTimeMillis()
+                return
+            }
+            destination = cleaned
             savedTime = System.currentTimeMillis()
         }
     }

--- a/app/src/main/res/xml/accessibility_config.xml
+++ b/app/src/main/res/xml/accessibility_config.xml
@@ -4,6 +4,6 @@
     android:accessibilityEventTypes="typeViewClicked|typeViewSelected"
     android:accessibilityFlags="flagDefault|flagReportViewIds"
     android:accessibilityFeedbackType="feedbackGeneric"
-    android:notificationTimeout="100"
+    android:notificationTimeout="300"
     android:canRetrieveWindowContent="true"
     />


### PR DESCRIPTION
## Summary
- NaverMap (v6.6.1.0, Compose UI) 의 `route_search_bar` 텍스트 중 출입구 옵션 POI 에서 마지막 텍스트가 "출입구 변경" UI 라벨이 되어 destination 으로 잘못 캡처되던 회귀 수정. "출입구 변경" 텍스트 노드의 y 좌표를 앵커로 사용해 위쪽 그룹의 last text 만 destination 후보로 사용. 문자열 매칭이 아닌 UI 구조 기반이라 POI 명에 "출입구"/"출입국"/"입구" 가 들어가도 안전.
- Compose UI 가 `TYPE_VIEW_CLICKED` 를 발화하지 않는 환경(실측)에 대응 — `TYPE_VIEW_SELECTED` 와 함께 수신해 capture 트리거 보장.
- 부수 견고화: `@Volatile` 동시성, `isVisibleToUser` 노드 스킵, 200ms 디바운스, opportunistic source-id 사전 필터, 동일 destination 중복 갱신 차단, TTL 3분→60초 단축, `accessibility_config notificationTimeout` 100→300ms.

## Test plan
- [x] 단순 POI (`야마다야`): destination = "야마다야" → 주소 변환 → Tesla 전송 요청 (실측)
- [x] 출입구 옵션 POI (`보정동 행정복지센터`): destination = "보정동 행정복지센터" (이전: "보정동주민센터주차장입구" 또는 "출입구 변경") → 주소 변환 → Tesla 전송 요청 (실측)
- [x] `TYPE_VIEW_SELECTED` 수신 확인 (NaverMap Compose 클릭 시)
- [x] `400_NAVIGATION` + `id=101` 알림 단일 발사 → NotificationListener → ShareWorker SUCCESS (실측)
- [ ] 경유지 + 출입구 옵션 동시 케이스 (디컴파일 + 동일 컴포넌트 분석 기반 안전 추정)
- [ ] POI 명에 "출입구" 포함 케이스 (예: "강남역 1번 출입구") — 앵커 "출입구 변경" 부재 시 전체 last 사용하므로 안전