### PR TITLE
fix: 페어링된 블루투스 이름이 null일 때 Spinner NPE 방지

### DIFF
--- a/app/src/main/kotlin/me/zipi/navitotesla/util/EnablerUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/EnablerUtil.kt
@@ -141,6 +141,6 @@ object EnablerUtil {
                 BluetoothManager::class.java,
             )
         val adapter = bluetoothManager.adapter ?: return emptyList()
-        return adapter.bondedDevices.map { it.name }
+        return adapter.bondedDevices.mapNotNull { it.name }
     }
 }


### PR DESCRIPTION
## Summary
- Play Store 크래시 리포트의 `ArrayAdapter.createViewFromResource` NPE 수정 (1.91.7cb542c7, Galaxy S9+ Android 10 외)
- `BluetoothDevice.getName()`은 페어링된 디바이스에서도 LMP 응답 지연/캐시 미스 시 `null`을 반환할 수 있어, 그대로 `ArrayAdapter`에 들어가면 설정 탭 → 블루투스 조건 추가 다이얼로그의 `Spinner` measure 단계(`item.toString()`)에서 NPE 발생
- `map { it.name }` → `mapNotNull { it.name }` 로 변경하여 이름 없는 디바이스를 목록에서 제외

## Test plan
- [ ] 설정 → 조건 사용 → 블루투스 추가 다이얼로그 정상 표시 (페어링된 디바이스 1개 이상 있는 단말)
- [ ] 디바이스 이름이 비어 있는 페어링 항목이 있어도 크래시 없이 다이얼로그 열림
- [ ] 선택 후 저장 시 정상적으로 조건 추가됨