### PR TITLE
fix: 접근성 진단 행에 공개 동의 다이얼로그 추가

### DIFF
--- a/app/src/main/kotlin/me/zipi/navitotesla/ui/setting/SettingFragment.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/ui/setting/SettingFragment.kt
@@ -145,7 +145,7 @@ class SettingFragment :
             R.string.diagPermAccessibility,
             R.string.guideRequireAccessibility,
             accOk,
-        ) { openAccessibilitySettings() }
+        ) { showAccessibilityConsentDialog() }
 
         val anyFail = !(notiOk && listenerOk && overlayOk && accOk)
         if (!diagnosticsUserToggled) {
@@ -448,18 +448,7 @@ class SettingFragment :
                     activity,
                 )
             ) {
-                AlertDialog
-                    .Builder(requireActivity())
-                    .setTitle(getString(R.string.guide))
-                    .setMessage(getString(R.string.accessibility_description))
-                    .setCancelable(true)
-                    .setPositiveButton(getString(R.string.allow)) { _: DialogInterface?, _: Int -> openAccessibilitySettings() }
-                    .setNegativeButton(getString(R.string.deny)) { _: DialogInterface?, _: Int ->
-                        setAccRadio(
-                            false,
-                        )
-                    }.create()
-                    .show()
+                showAccessibilityConsentDialog(onDeny = { setAccRadio(false) })
             }
         } else if (checkedId == R.id.radioDuplicatePoiShowPopup) {
             if (!isDuplicatePoiRadioInitializing) {
@@ -516,6 +505,21 @@ class SettingFragment :
         } catch (e: ActivityNotFoundException) {
             startActivity(Intent(Settings.ACTION_SETTINGS))
         }
+    }
+
+    private fun showAccessibilityConsentDialog(onDeny: () -> Unit = {}) {
+        if (activity == null) return
+        AlertDialog
+            .Builder(requireActivity())
+            .setTitle(getString(R.string.guide))
+            .setMessage(getString(R.string.accessibility_description))
+            .setCancelable(true)
+            .setPositiveButton(getString(R.string.allow)) { _: DialogInterface?, _: Int ->
+                openAccessibilitySettings()
+            }.setNegativeButton(getString(R.string.deny)) { _: DialogInterface?, _: Int ->
+                onDeny()
+            }.create()
+            .show()
     }
 
     private fun showOverlayPermissionDialog() {

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/AnalysisUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/AnalysisUtil.kt
@@ -9,6 +9,7 @@ import com.google.firebase.crashlytics.FirebaseCrashlytics
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlin.coroutines.cancellation.CancellationException
 import java.io.BufferedWriter
 import java.io.File
 import java.io.FileNotFoundException
@@ -66,7 +67,9 @@ object AnalysisUtil {
         get() = externalDir != null
 
     fun recordException(e: Throwable) {
-        firebaseCrashlytics.recordException(e)
+        if (e !is CancellationException) {
+            firebaseCrashlytics.recordException(e)
+        }
         PrintWriter(StringWriter()).use { writer ->
             e.printStackTrace(writer)
             appendLog("WARN", e.toString() + System.lineSeparator() + writer)


### PR DESCRIPTION
## Summary
- 설정 탭 진단 섹션의 접근성 "허용" 버튼이 시스템 설정 화면으로 곧바로 이동하던 흐름을, 전체 공개(accessibility_description) 동의 다이얼로그를 거치도록 수정. 1.94 Google Play 정책(접근성 API 명시적 공개) 거절 사유 대응.
- 라디오 버튼/진단 행이 공유하는 `showAccessibilityConsentDialog()` 헬퍼로 통합.
- `AnalysisUtil.recordException` 에서 `CancellationException` 은 Crashlytics 기록 대상에서 제외 (코루틴 정상 취소가 오류로 잡히는 잡음 제거).

## Test plan
- [ ] 접근성 비활성 상태에서 설정 탭 → 점검 섹션 → "허용" 클릭 시 전체 공개 텍스트 다이얼로그가 뜨고, "허용" 눌러야 시스템 설정 이동
- [ ] "거부" 누르면 다이얼로그만 닫히고 시스템 설정으로 이동하지 않음
- [ ] 기존 라디오 버튼(접근성 활성화) 흐름도 동일 다이얼로그로 동작, "거부" 시 라디오가 비활성 상태로 되돌아감
- [ ] 코루틴 취소가 발생하는 경로(예: Fragment 이탈 중 진행 중인 요청 취소)에서 Crashlytics 비정상 기록이 사라지는지 확인