### PR TITLE
test: 핵심 흐름 회귀 테스트 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,6 +74,12 @@ android {
         buildConfig = true
         resValues = true
     }
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+            isReturnDefaultValues = true
+        }
+    }
     namespace = "me.zipi.navitotesla"
 }
 
@@ -114,6 +120,11 @@ dependencies {
     implementation(libs.bundles.firebase)
 
     testImplementation(libs.junit)
+    testImplementation(libs.androidx.test.core)
+    testImplementation(libs.androidx.work.testing)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.mockk)
+    testImplementation(libs.robolectric)
     androidTestImplementation(libs.androidx.test.junit)
     androidTestImplementation(libs.androidx.test.espresso)
 }

--- a/app/src/main/kotlin/me/zipi/navitotesla/receiver/NotificationListener.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/receiver/NotificationListener.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.service.notification.NotificationListenerService
 import android.service.notification.StatusBarNotification
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import com.google.firebase.analytics.FirebaseAnalytics
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -21,7 +22,9 @@ import me.zipi.navitotesla.util.RemoteConfigUtil
 
 class NotificationListener : NotificationListenerService() {
     private lateinit var naviToTeslaService: NaviToTeslaService
-    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    @VisibleForTesting
+    internal var serviceScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onCreate() {
         super.onCreate()

--- a/app/src/test/kotlin/me/zipi/navitotesla/TestApplication.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/TestApplication.kt
@@ -1,0 +1,9 @@
+package me.zipi.navitotesla
+
+import android.app.Application
+
+/**
+ * Robolectric 가 운영용 [me.zipi.navitotesla.Application] 을 띄우려 하면 EncryptedSharedPreferences /
+ * Room / Firebase 초기화가 JVM 환경에서 줄줄이 깨진다. 테스트에서는 아무것도 안 하는 빈 Application 으로 대체.
+ */
+class TestApplication : Application()

--- a/app/src/test/kotlin/me/zipi/navitotesla/background/ShareWorkerStartShareTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/background/ShareWorkerStartShareTest.kt
@@ -1,0 +1,89 @@
+package me.zipi.navitotesla.background
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.WorkManager
+import androidx.work.WorkRequest
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import me.zipi.navitotesla.TestApplication
+import me.zipi.navitotesla.util.AnalysisUtil
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], manifest = Config.NONE, application = TestApplication::class)
+class ShareWorkerStartShareTest {
+    private lateinit var context: Context
+    private lateinit var workManager: WorkManager
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+
+        // JVM 환경에서 Firebase / AnalysisUtil 부수효과 차단.
+        mockkStatic(FirebaseCrashlytics::class)
+        every { FirebaseCrashlytics.getInstance() } returns mockk(relaxed = true)
+        mockkObject(AnalysisUtil)
+        every { AnalysisUtil.log(any()) } returns Unit
+
+        // WorkManager.Companion 의 getInstance 를 가로채 enqueue 만 캡처.
+        workManager = mockk(relaxed = true)
+        mockkObject(WorkManager.Companion)
+        every { WorkManager.getInstance(any()) } returns workManager
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `startShare enqueues a ShareWorker WorkRequest with TMap input data`() {
+        ShareWorker.startShare(
+            context,
+            packageName = "com.skt.tmap.ku",
+            notificationTitle = "경로주행",
+            notificationText = "내 위치 > 강남역",
+        )
+
+        val captured = slot<WorkRequest>()
+        verify(exactly = 1) { workManager.enqueue(capture(captured)) }
+
+        val spec = captured.captured.workSpec
+        assertEquals(ShareWorker::class.java.name, spec.workerClassName)
+        assertEquals("com.skt.tmap.ku", spec.input.getString("packageName"))
+        assertEquals("경로주행", spec.input.getString("notificationTitle"))
+        assertEquals("내 위치 > 강남역", spec.input.getString("notificationText"))
+    }
+
+    @Test
+    fun `startShare enqueues a ShareWorker WorkRequest with Kakao input data`() {
+        ShareWorker.startShare(
+            context,
+            packageName = "com.locnall.KimGiSa",
+            notificationTitle = "길안내 주행 중",
+            notificationText = "목적지 : 송파구청",
+        )
+
+        val captured = slot<WorkRequest>()
+        verify(exactly = 1) { workManager.enqueue(capture(captured)) }
+
+        val spec = captured.captured.workSpec
+        assertEquals(ShareWorker::class.java.name, spec.workerClassName)
+        assertEquals("com.locnall.KimGiSa", spec.input.getString("packageName"))
+        assertEquals("길안내 주행 중", spec.input.getString("notificationTitle"))
+        assertEquals("목적지 : 송파구청", spec.input.getString("notificationText"))
+    }
+}

--- a/app/src/test/kotlin/me/zipi/navitotesla/receiver/NotificationListenerTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/receiver/NotificationListenerTest.kt
@@ -1,0 +1,177 @@
+package me.zipi.navitotesla.receiver
+
+import android.app.Notification
+import android.content.Context
+import android.os.Bundle
+import android.os.UserHandle
+import android.service.notification.StatusBarNotification
+import androidx.test.core.app.ApplicationProvider
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import me.zipi.navitotesla.TestApplication
+import me.zipi.navitotesla.background.ShareWorker
+import me.zipi.navitotesla.background.VersionCheckWorker
+import me.zipi.navitotesla.service.NaviToTeslaAccessibilityService
+import me.zipi.navitotesla.util.AnalysisUtil
+import me.zipi.navitotesla.util.RemoteConfigUtil
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * 핵심 회귀 방지: 지원하는 내비 앱(TMap / Kakao)의 알림이 들어오면 ShareWorker 가 큐잉되어야 하고,
+ * 지원하지 않는 패키지는 무시되어야 한다. PoiFinder 호출과 WorkManager 동작 자체는 의존성이라
+ * 여기선 직접 검증하지 않고, ShareWorker.startShare 가 정확한 인자로 불리는지 spy 로 확인한다.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], manifest = Config.NONE, application = TestApplication::class)
+class NotificationListenerTest {
+    private lateinit var context: Context
+    private lateinit var listener: NotificationListener
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+
+        mockkStatic(FirebaseCrashlytics::class)
+        every { FirebaseCrashlytics.getInstance() } returns mockk(relaxed = true)
+        mockkObject(AnalysisUtil)
+        every { AnalysisUtil.log(any()) } returns Unit
+        every { AnalysisUtil.logEvent(any(), any()) } returns Unit
+        every { AnalysisUtil.setCustomKey(any(), any<String>()) } returns Unit
+
+        mockkObject(ShareWorker.Companion)
+        every { ShareWorker.startShare(any(), any(), any(), any()) } returns Unit
+
+        mockkObject(VersionCheckWorker.Companion)
+        every { VersionCheckWorker.startVersionCheck(any()) } returns Unit
+
+        mockkObject(NaviToTeslaAccessibilityService.Companion)
+        every { NaviToTeslaAccessibilityService.notifyIfAvailable(any(), any()) } returns Unit
+
+        mockkObject(RemoteConfigUtil)
+        every { RemoteConfigUtil.initialize() } returns Unit
+
+        listener = Robolectric.buildService(NotificationListener::class.java).get()
+        // 코루틴이 즉시 동기 실행되도록 dispatcher 교체.
+        listener.serviceScope = CoroutineScope(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `TMap (KU) 알림 수신 시 ShareWorker startShare 가 호출된다`() {
+        val sbn = buildSbn(
+            packageName = "com.skt.tmap.ku",
+            title = "경로주행",
+            text = "내 위치 > 강남역",
+        )
+
+        listener.onNotificationPosted(sbn)
+
+        verify(exactly = 1) {
+            ShareWorker.startShare(
+                any(),
+                eq("com.skt.tmap.ku"),
+                eq("경로주행"),
+                eq("내 위치 > 강남역"),
+            )
+        }
+    }
+
+    @Test
+    fun `TMap (SK) 알림 수신 시 ShareWorker startShare 가 호출된다`() {
+        val sbn = buildSbn(
+            packageName = "com.skt.skaf.l001mtm091",
+            title = "경로주행",
+            text = "내 위치 > 송파구청",
+        )
+
+        listener.onNotificationPosted(sbn)
+
+        verify(exactly = 1) {
+            ShareWorker.startShare(
+                any(),
+                eq("com.skt.skaf.l001mtm091"),
+                eq("경로주행"),
+                eq("내 위치 > 송파구청"),
+            )
+        }
+    }
+
+    @Test
+    fun `KakaoNavi 알림 수신 시 ShareWorker startShare 가 호출된다`() {
+        val sbn = buildSbn(
+            packageName = "com.locnall.KimGiSa",
+            title = "길안내 주행 중",
+            text = "목적지 : 송파구청",
+        )
+
+        listener.onNotificationPosted(sbn)
+
+        verify(exactly = 1) {
+            ShareWorker.startShare(
+                any(),
+                eq("com.locnall.KimGiSa"),
+                eq("길안내 주행 중"),
+                eq("목적지 : 송파구청"),
+            )
+        }
+    }
+
+    @Test
+    fun `지원하지 않는 패키지의 알림은 ShareWorker 를 호출하지 않는다`() {
+        val sbn = buildSbn(
+            packageName = "com.google.android.apps.maps",
+            title = "Driving",
+            text = "Continue ahead",
+        )
+
+        listener.onNotificationPosted(sbn)
+
+        verify(exactly = 0) {
+            ShareWorker.startShare(any(), any(), any(), any())
+        }
+    }
+
+    private fun buildSbn(
+        packageName: String,
+        title: String,
+        text: String,
+    ): StatusBarNotification {
+        val notification = Notification().apply {
+            extras = Bundle().apply {
+                putString(Notification.EXTRA_TITLE, title)
+                putString(Notification.EXTRA_TEXT, text)
+            }
+        }
+        return StatusBarNotification(
+            /* pkg = */ packageName,
+            /* opPkg = */ packageName,
+            /* id = */ 1,
+            /* tag = */ "tag",
+            /* uid = */ 0,
+            /* initialPid = */ 0,
+            /* score = */ 0,
+            /* notification = */ notification,
+            /* user = */ UserHandle.getUserHandleForUid(0),
+            /* postTime = */ System.currentTimeMillis(),
+        )
+    }
+}

--- a/app/src/test/kotlin/me/zipi/navitotesla/service/poifinder/KakaoPoiFinderTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/service/poifinder/KakaoPoiFinderTest.kt
@@ -1,0 +1,42 @@
+package me.zipi.navitotesla.service.poifinder
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KakaoPoiFinderTest {
+    private val finder = KakaoPoiFinder()
+
+    @Test
+    fun `parseDestination strips 목적지 prefix`() {
+        assertEquals("송파구청", finder.parseDestination("목적지 : 송파구청"))
+    }
+
+    @Test
+    fun `parseDestination trims whitespace`() {
+        assertEquals("강남역", finder.parseDestination("  목적지 : 강남역  "))
+    }
+
+    @Test
+    fun `parseDestination returns input as-is when prefix missing`() {
+        assertEquals("그냥문자열", finder.parseDestination("그냥문자열"))
+    }
+
+    @Test
+    fun `isIgnore returns false for valid 길안내 주행 중 notification`() {
+        assertFalse(finder.isIgnore("길안내 주행 중", "목적지 : 송파구청"))
+    }
+
+    @Test
+    fun `isIgnore returns true when title is not 길안내 주행 중`() {
+        assertTrue(finder.isIgnore("일반 알림", "목적지 : 송파구청"))
+        assertTrue(finder.isIgnore("", "목적지 : 송파구청"))
+    }
+
+    @Test
+    fun `isIgnore returns true when text does not contain 목적지 prefix`() {
+        assertTrue(finder.isIgnore("길안내 주행 중", "다른 텍스트"))
+        assertTrue(finder.isIgnore("길안내 주행 중", ""))
+    }
+}

--- a/app/src/test/kotlin/me/zipi/navitotesla/service/poifinder/PoiFinderFactoryTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/service/poifinder/PoiFinderFactoryTest.kt
@@ -1,0 +1,72 @@
+package me.zipi.navitotesla.service.poifinder
+
+import me.zipi.navitotesla.exception.NotSupportedNaviException
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PoiFinderFactoryTest {
+    @Test
+    fun `isNaviSupport returns true for TMap (KU)`() {
+        assertTrue(PoiFinderFactory.isNaviSupport("com.skt.tmap.ku"))
+    }
+
+    @Test
+    fun `isNaviSupport returns true for TMap (SK)`() {
+        assertTrue(PoiFinderFactory.isNaviSupport("com.skt.skaf.l001mtm091"))
+    }
+
+    @Test
+    fun `isNaviSupport returns true for KakaoNavi`() {
+        assertTrue(PoiFinderFactory.isNaviSupport("com.locnall.KimGiSa"))
+    }
+
+    @Test
+    fun `isNaviSupport returns true for Naver Map`() {
+        assertTrue(PoiFinderFactory.isNaviSupport("com.nhn.android.nmap"))
+    }
+
+    @Test
+    fun `isNaviSupport is case insensitive`() {
+        assertTrue(PoiFinderFactory.isNaviSupport("COM.SKT.TMAP.KU"))
+        assertTrue(PoiFinderFactory.isNaviSupport("com.LOCNALL.kimgisa"))
+    }
+
+    @Test
+    fun `isNaviSupport returns false for unsupported package`() {
+        assertFalse(PoiFinderFactory.isNaviSupport("com.google.android.apps.maps"))
+        assertFalse(PoiFinderFactory.isNaviSupport("com.example.unknown"))
+        assertFalse(PoiFinderFactory.isNaviSupport(""))
+    }
+
+    @Test
+    fun `isNaverMap distinguishes Naver vs others`() {
+        assertTrue(PoiFinderFactory.isNaverMap("com.nhn.android.nmap"))
+        assertFalse(PoiFinderFactory.isNaverMap("com.skt.tmap.ku"))
+        assertFalse(PoiFinderFactory.isNaverMap("com.locnall.KimGiSa"))
+    }
+
+    @Test
+    fun `getPoiFinder returns TMapPoiFinder for TMap packages`() {
+        assertTrue(PoiFinderFactory.getPoiFinder("com.skt.tmap.ku") is TMapPoiFinder)
+        assertTrue(PoiFinderFactory.getPoiFinder("com.skt.skaf.l001mtm091") is TMapPoiFinder)
+    }
+
+    @Test
+    fun `getPoiFinder returns KakaoPoiFinder for KakaoNavi`() {
+        assertTrue(PoiFinderFactory.getPoiFinder("com.locnall.KimGiSa") is KakaoPoiFinder)
+    }
+
+    @Test
+    fun `getPoiFinder returns NaverPoiFinder for Naver Map`() {
+        assertTrue(PoiFinderFactory.getPoiFinder("com.nhn.android.nmap") is NaverPoiFinder)
+    }
+
+    @Test
+    fun `getPoiFinder throws NotSupportedNaviException for unknown package`() {
+        assertThrows(NotSupportedNaviException::class.java) {
+            PoiFinderFactory.getPoiFinder("com.example.unknown")
+        }
+    }
+}

--- a/app/src/test/kotlin/me/zipi/navitotesla/service/poifinder/TMapPoiFinderTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/service/poifinder/TMapPoiFinderTest.kt
@@ -1,0 +1,55 @@
+package me.zipi.navitotesla.service.poifinder
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TMapPoiFinderTest {
+    private val finder = TMapPoiFinder()
+
+    @Test
+    fun `parseDestination returns last segment for 출발지 to 목적지`() {
+        assertEquals("강남역", finder.parseDestination("내 위치 > 강남역"))
+    }
+
+    @Test
+    fun `parseDestination returns last segment when waypoint exists`() {
+        assertEquals("송파구청", finder.parseDestination("내 위치 > 경유지 > 송파구청"))
+    }
+
+    @Test
+    fun `parseDestination returns last segment for multi waypoints`() {
+        assertEquals(
+            "도착지",
+            finder.parseDestination("출발 > 경유1 > 경유2 > 도착지"),
+        )
+    }
+
+    @Test
+    fun `parseDestination returns trimmed input when no separator present`() {
+        assertEquals("단일목적지", finder.parseDestination("  단일목적지  "))
+    }
+
+    @Test
+    fun `parseDestination skips trailing blank segments`() {
+        // "출발 > " → ["출발 ", " "] → last non-blank = "출발"
+        assertEquals("출발", finder.parseDestination("출발 > "))
+    }
+
+    @Test
+    fun `isIgnore returns false for 경로주행 with normal destination text`() {
+        assertFalse(finder.isIgnore("경로주행", "내 위치 > 강남역"))
+    }
+
+    @Test
+    fun `isIgnore returns true when text is 안심주행`() {
+        assertTrue(finder.isIgnore("경로주행", "안심주행"))
+    }
+
+    @Test
+    fun `isIgnore returns true when title is not 경로주행`() {
+        assertTrue(finder.isIgnore("일반 알림", "내 위치 > 강남역"))
+        assertTrue(finder.isIgnore("", "내 위치 > 강남역"))
+    }
+}

--- a/app/src/test/kotlin/me/zipi/navitotesla/util/EnablerUtilIsSendingCheckTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/util/EnablerUtilIsSendingCheckTest.kt
@@ -1,0 +1,134 @@
+package me.zipi.navitotesla.util
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.test.runTest
+import me.zipi.navitotesla.db.AppDatabase
+import me.zipi.navitotesla.db.ConditionDao
+import me.zipi.navitotesla.db.ConditionEntity
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.Date
+
+/**
+ * `EnablerUtil.isSendingCheck()` 는 사용자가 설정한 블루투스/조건 게이트로 안내 전송 여부를 결정한다.
+ * 이 분기가 잘못 변경되면 의도치 않은 목적지가 차량으로 전송되거나, 반대로 정상 케이스가 전부 무시될 수 있다.
+ *
+ * 모든 분기를 커버:
+ * 1. appEnabled = false                                            → false
+ * 2. appEnabled = true, appCondition = false                       → true (조건 비활성, 무조건 통과)
+ * 3. appCondition = true, 조건 목록 모두 비어있음                  → true (조건이 없으면 통과)
+ * 4. 블루투스 조건 존재 + 매칭되는 블루투스 연결됨                 → true
+ * 5. 블루투스 조건 존재 + 연결된 블루투스가 일치하지 않음          → false
+ * 6. 블루투스 조건 존재 + 연결된 블루투스 없음                     → false
+ * 7. 블루투스 매칭은 대소문자 무시 (저장은 lowercase, 조건은 자유) → true
+ */
+class EnablerUtilIsSendingCheckTest {
+    private lateinit var dao: ConditionDao
+
+    @Before
+    fun setUp() {
+        mockkStatic(FirebaseCrashlytics::class)
+        every { FirebaseCrashlytics.getInstance() } returns mockk(relaxed = true)
+        mockkObject(AnalysisUtil)
+        every { AnalysisUtil.log(any()) } returns Unit
+
+        mockkObject(PreferencesUtil)
+        mockkObject(AppDatabase)
+        dao = mockk()
+        val db = mockk<AppDatabase>()
+        every { AppDatabase.getInstance() } returns db
+        every { db.conditionDao() } returns dao
+
+        // 기본값 — 각 테스트에서 필요 시 덮어씀.
+        coEvery { PreferencesUtil.getBoolean("appEnabled", true) } returns true
+        coEvery { PreferencesUtil.getBoolean("appCondition", false) } returns false
+        coEvery { dao.findCondition("wifi") } returns emptyList()
+        coEvery { dao.findCondition("bluetooth") } returns emptyList()
+
+        clearConnectedBluetooth()
+    }
+
+    @After
+    fun tearDown() {
+        clearConnectedBluetooth()
+        unmockkAll()
+    }
+
+    @Test
+    fun `appEnabled=false 면 false`() = runTest {
+        coEvery { PreferencesUtil.getBoolean("appEnabled", true) } returns false
+
+        assertFalse(EnablerUtil.isSendingCheck())
+    }
+
+    @Test
+    fun `appEnabled=true, appCondition=false 면 true`() = runTest {
+        // 기본 setUp 그대로
+        assertTrue(EnablerUtil.isSendingCheck())
+    }
+
+    @Test
+    fun `appCondition=true 인데 wifi-bluetooth 조건이 모두 비어있으면 true`() = runTest {
+        coEvery { PreferencesUtil.getBoolean("appCondition", false) } returns true
+
+        assertTrue(EnablerUtil.isSendingCheck())
+    }
+
+    @Test
+    fun `블루투스 조건과 일치하는 디바이스가 연결돼 있으면 true`() = runTest {
+        coEvery { PreferencesUtil.getBoolean("appCondition", false) } returns true
+        coEvery { dao.findCondition("bluetooth") } returns listOf(condition("MyCar"))
+        EnablerUtil.addConnectedBluetooth("MyCar")
+
+        assertTrue(EnablerUtil.isSendingCheck())
+    }
+
+    @Test
+    fun `블루투스 조건은 있지만 연결된 디바이스가 다른 이름이면 false`() = runTest {
+        coEvery { PreferencesUtil.getBoolean("appCondition", false) } returns true
+        coEvery { dao.findCondition("bluetooth") } returns listOf(condition("MyCar"))
+        EnablerUtil.addConnectedBluetooth("OtherCar")
+
+        assertFalse(EnablerUtil.isSendingCheck())
+    }
+
+    @Test
+    fun `블루투스 조건은 있지만 연결된 디바이스가 없으면 false`() = runTest {
+        coEvery { PreferencesUtil.getBoolean("appCondition", false) } returns true
+        coEvery { dao.findCondition("bluetooth") } returns listOf(condition("MyCar"))
+
+        assertFalse(EnablerUtil.isSendingCheck())
+    }
+
+    @Test
+    fun `블루투스 매칭은 대소문자를 무시한다`() = runTest {
+        coEvery { PreferencesUtil.getBoolean("appCondition", false) } returns true
+        coEvery { dao.findCondition("bluetooth") } returns listOf(condition("MyCar"))
+        EnablerUtil.addConnectedBluetooth("MYCAR")
+
+        assertTrue(EnablerUtil.isSendingCheck())
+    }
+
+    private fun condition(name: String) = ConditionEntity(name = name, type = "bluetooth", created = Date())
+
+    /**
+     * `EnablerUtil.connectedBluetoothDevice` 는 object 내부의 private MutableSet 이라 테스트 간 상태가 남는다.
+     * 추가했던 이름만 정확히 알기 어렵고 다른 테스트가 셋에 의존하지도 않게, 매 테스트 시작/종료 시 비운다.
+     */
+    private fun clearConnectedBluetooth() {
+        val field = EnablerUtil::class.java.getDeclaredField("connectedBluetoothDevice")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val set = field.get(EnablerUtil) as MutableSet<String>
+        synchronized(set) { set.clear() }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,6 +53,11 @@ firebase-perf = { module = "com.google.firebase:firebase-perf" }
 junit = "junit:junit:4.13.2"
 androidx-test-junit = "androidx.test.ext:junit:1.3.0"
 androidx-test-espresso = "androidx.test.espresso:espresso-core:3.7.0"
+androidx-test-core = "androidx.test:core:1.7.0"
+androidx-work-testing = "androidx.work:work-testing:2.11.2"
+kotlinx-coroutines-test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0"
+mockk = "io.mockk:mockk:1.14.4"
+robolectric = "org.robolectric:robolectric:4.16"
 
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 retrofit-converter = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofit" }


### PR DESCRIPTION
## Summary
- 그동안 테스트가 `ExampleUnitTest` 1개뿐이라 핵심 흐름만 안전망 추가
- 노티 리스너 → ShareWorker 호출, POI 파서, 조건 게이트(`isSendingCheck`) 회귀 방지

## 추가된 테스트
- `NotificationListenerTest`: TMap/Kakao 알림 → ShareWorker 호출 검증
- `ShareWorkerStartShareTest`: WorkRequest inputData 검증
- `PoiFinderFactoryTest` / `TMapPoiFinderTest` / `KakaoPoiFinderTest`
- `EnablerUtilIsSendingCheckTest`: 블루투스 조건 분기 7케이스

총 38 케이스. `./gradlew build` 시 자동 실행됨.