### PR TITLE
refactor: 점검에서 접근성 행 제거

### DIFF
--- a/app/src/main/kotlin/me/zipi/navitotesla/ui/setting/SettingFragment.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/ui/setting/SettingFragment.kt
@@ -121,7 +121,6 @@ class SettingFragment :
                 .getEnabledListenerPackages(ctx)
                 .contains(ctx.packageName)
         val overlayOk = Settings.canDrawOverlays(ctx)
-        val accOk = NaviToTeslaAccessibilityService.isAccessibilityServiceEnabled(ctx)
         bindDiagnosticRow(
             binding.diagRowNotification,
             R.string.diagPermNotification,
@@ -140,14 +139,8 @@ class SettingFragment :
             R.string.guideGrantOverlayPermission,
             overlayOk,
         ) { openOverlaySettings() }
-        bindDiagnosticRow(
-            binding.diagRowAccessibility,
-            R.string.diagPermAccessibility,
-            R.string.guideRequireAccessibility,
-            accOk,
-        ) { showAccessibilityConsentDialog() }
 
-        val anyFail = !(notiOk && listenerOk && overlayOk && accOk)
+        val anyFail = !(notiOk && listenerOk && overlayOk)
         if (!diagnosticsUserToggled) {
             applyDiagnosticsExpanded(anyFail)
         }

--- a/app/src/main/res/layout-land/fragment_settings.xml
+++ b/app/src/main/res/layout-land/fragment_settings.xml
@@ -197,12 +197,6 @@
                             layout="@layout/view_diagnostic_row"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content" />
-
-                        <include
-                            android:id="@+id/diagRowAccessibility"
-                            layout="@layout/view_diagnostic_row"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content" />
                     </LinearLayout>
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -190,12 +190,6 @@
                         layout="@layout/view_diagnostic_row"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content" />
-
-                    <include
-                        android:id="@+id/diagRowAccessibility"
-                        layout="@layout/view_diagnostic_row"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content" />
                 </LinearLayout>
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -102,7 +102,6 @@
     <string name="diagPermNotification">Notification</string>
     <string name="diagPermNotificationListener">Notification access</string>
     <string name="diagPermOverlay">Display over other apps</string>
-    <string name="diagPermAccessibility">Accessibility service</string>
     <string name="diagOk">OK</string>
     <string name="diagFix">Allow</string>
     <string name="diagInfo">Info</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -102,7 +102,6 @@
     <string name="diagPermNotification">알림 권한</string>
     <string name="diagPermNotificationListener">알림 접근 권한</string>
     <string name="diagPermOverlay">다른 앱 위에 표시</string>
-    <string name="diagPermAccessibility">접근성 서비스</string>
     <string name="diagOk">정상</string>
     <string name="diagFix">허용</string>
     <string name="diagInfo">설명</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,7 +107,6 @@
     <string name="diagPermNotification">Notification</string>
     <string name="diagPermNotificationListener">Notification access</string>
     <string name="diagPermOverlay">Display over other apps</string>
-    <string name="diagPermAccessibility">Accessibility service</string>
     <string name="diagOk">OK</string>
     <string name="diagFix">Allow</string>
     <string name="diagInfo">Info</string>


### PR DESCRIPTION
## Summary
- 접근성은 네이버내비에서만 쓰는 옵션 기능이라, 점검 섹션에 항상 노출되는 게 부적절
- 시스템이 임의로 꺼버리는 케이스는 `RelaunchNotifier` / `notifyRequireAccessibility` 알림에서 따로 안내함
- 활성 상태는 설정 탭의 라디오 버튼에서 보임

## Test plan
- [ ] 설정 탭 점검 섹션에 접근성 행이 없음
- [ ] 라디오 버튼/동의 다이얼로그는 그대로 동작