### PR TITLE
feat: 중복 목적지 스킵 시 상세 로그 추가

### DIFF
--- a/app/src/main/kotlin/me/zipi/navitotesla/service/NaviToTeslaService.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/NaviToTeslaService.kt
@@ -85,6 +85,10 @@ class NaviToTeslaService(
                     share(poi)
                 }
             } else {
+                val deltaMs = if (lastShareAt > 0L) System.currentTimeMillis() - lastShareAt else -1L
+                AnalysisUtil.log(
+                    "skip share: duplicate dest, pkg=$packageName, addr=${poi.getRoadAddress()}, deltaMs=$deltaMs",
+                )
                 AnalysisUtil.logEvent("previous_request_address", eventParam)
             }
             appRepository.clearExpiredPoi()
@@ -139,6 +143,7 @@ class NaviToTeslaService(
                 },
         )
         if (!poi.isAddressEmpty()) {
+            lastShareAt = System.currentTimeMillis()
             makeToast(context.getString(R.string.requestSend) + "\n" + poi.getRoadAddress())
             val shareMode = PreferencesUtil.getString("shareMode", "app")
             if (shareMode == "api" && PreferencesUtil.loadToken() != null) {
@@ -314,5 +319,8 @@ class NaviToTeslaService(
 
     companion object {
         private val ADDRESS_PATTERN = Pattern.compile("^(?:[가-힣]+\\s[가-힣]+[시군구]|(?:세종시|세종특별시|세종특별자치시)\\s[가-힣\\d]+[읍면동로])\\s")
+
+        @Volatile
+        private var lastShareAt: Long = 0L
     }
 }


### PR DESCRIPTION
## Summary
- `share()` 가 직전 안내와 동일한 주소라 스킵할 때 `AnalysisUtil.log` 로 `pkg`, `addr`, `deltaMs` 기록
- 1.94 에서 ShareWorker 로그는 있는데 전송이 안 됐던 케이스 원인 추적용
- `deltaMs` 로 시스템 재방송(짧음) vs 사용자 재시도(긺) 구분 가능

## Test plan
- [ ] 같은 목적지 두 번 안내 시 Crashlytics breadcrumb 에 `skip share: duplicate dest ...` 라인이 남는지 확인