### PR TITLE
fix: 즐겨찾기 별명으로 안내 시작 시 전송 안 되던 문제

### DIFF
--- a/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
@@ -90,12 +90,16 @@ class AppRepository private constructor(
     suspend fun getPoiSync(
         poiName: String,
         packageName: String = "",
-    ): PoiAddressEntity? =
-        if (packageName.isNotEmpty()) {
-            database.poiAddressDao().findPoiByPackage(poiName, packageName)
-        } else {
-            database.poiAddressDao().findPoiLatest(poiName)
-        }
+    ): PoiAddressEntity? {
+        val byPackage =
+            if (packageName.isNotEmpty()) {
+                database.poiAddressDao().findPoiByPackage(poiName, packageName)
+            } else {
+                database.poiAddressDao().findPoiLatest(poiName)
+            }
+        if (byPackage != null) return byPackage
+        return database.poiAddressDao().findRegisteredByPoi(poiName)
+    }
 
     suspend fun savePoi(
         poi: Poi,

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/NaviToTeslaService.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/NaviToTeslaService.kt
@@ -150,6 +150,11 @@ class NaviToTeslaService(
             } else {
                 TeslaShareByApp(context).share(poi)
             }
+        } else {
+            AnalysisUtil.log("share skipped: empty poi name=${poi.poiName}, pkg=${poi.packageName}")
+            makeToast(
+                context.getString(R.string.sendDestinationFail) + "\n" + context.getString(R.string.addressNotFound),
+            )
         }
     }
 

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -26,6 +26,7 @@
     <string name="requestSend">Request to send destination</string>
     <string name="sendDestinationSuccess">Success to send destination</string>
     <string name="duplicatedPoiName">Duplicated destination</string>
+    <string name="addressNotFound">Address not found</string>
     <string name="unsupportedNavi">Unsupported navigation</string>
     <string name="authFail">Authentication failed</string>
     <string name="apiError">Internal or API error</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -26,6 +26,7 @@
     <string name="requestSend">목적지 전송 요청</string>
     <string name="sendDestinationSuccess">목적지 전송 성공</string>
     <string name="duplicatedPoiName">목적지 중복</string>
+    <string name="addressNotFound">주소를 찾을 수 없습니다</string>
     <string name="unsupportedNavi">미지원 내비</string>
     <string name="authFail">인증 실패</string>
     <string name="apiError">내부 또는 API 오류</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="requestSend">Request to send destination</string>
     <string name="sendDestinationSuccess">Success to send destination</string>
     <string name="duplicatedPoiName">Duplicated destination</string>
+    <string name="addressNotFound">Address not found</string>
     <string name="unsupportedNavi">Unsupported navigation</string>
     <string name="authFail">Authentication failed</string>
     <string name="apiError">Internal or API error</string>


### PR DESCRIPTION
## Summary
- 사용자가 앱 즐겨찾기에 등록한 별명(예: "회사")으로 TMap/Kakao 안내 시작 시 Tesla 전송이 조용히 무시되던 버그 수정
- 빈 POI 일 때도 토스트로 사용자에게 알리도록 보강 (지금까지는 silent drop)

## Root cause
PR #327 회귀. `AppRepository.getPoiSync` 가 packageName 까지 매칭하도록 바뀌었는데, `FavoriteDialogFragment.saveFavorite()` 는 packageName 안 채우고 저장 → 노티 트리거 시 매칭 실패 → API fallback 도 별명이라 못 찾음 → 빈 POI → 전송 분기 미진입.

## Fix
1. `getPoiSync` 에 `findRegisteredByPoi` 폴백 추가 — packageName 일치 매칭이 없으면 등록 즐겨찾기를 패키지 무관하게 매칭
2. `share(poi)` 의 빈 POI 분기에 `addressNotFound` 토스트 + 로그 추가

## Test plan
- [ ] 즐겨찾기 미등록 상태에서 TMap "판교집" 으로 안내 시 토스트 노출
- [ ] 즐겨찾기 등록 후 동일 안내 시 Tesla 전송됨