### PR TITLE
fix: 업데이트 릴리즈 노트 개선

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -104,18 +104,11 @@ jobs:
             -f target_commitish="$GITHUB_SHA" \
             --jq .body)
 
-          # Dependencies 섹션을 HTML 주석으로 감싸 렌더링 시 숨김 (소스에는 남음).
-          transformed=$(echo "$notes" | awk '
-            BEGIN { in_deps = 0 }
-            /^### Dependencies$/ { in_deps = 1; print "<!--"; print; next }
-            in_deps && (/^### / || /^## / || /^\*\*Full Changelog/) { in_deps = 0; print "-->"; print; next }
-            { print }
-            END { if (in_deps) print "-->" }
-          ')
-
+          # 자동 생성 노트 전체를 HTML 주석으로 감싸 렌더링 시 숨김.
+          # 사용자 입력 description 만 표면에 노출, 자동 노트는 raw/edit 뷰에서만 확인 가능.
           {
             printf '%s\n\n' "$USER_BODY"
-            printf '%s\n' "$transformed"
+            printf '<!--\n%s\n-->\n' "$notes"
           } > release-notes.md
 
           echo "===== release-notes.md ====="
@@ -154,6 +147,7 @@ jobs:
           packageName: me.zipi.navitotesla
           releaseFiles: ${{ steps.sign_aab.outputs.signedReleaseFile }}
           releaseName: ${{ env.RELEASE }}
-          track: internal
+          tracks: internal
           status: completed
+          changesNotSentForReview: true
           mappingFile: app/build/outputs/mapping/playstoreRelease/mapping.txt

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -11,6 +11,11 @@ on:
         description: 'Release description'
         required: true
         default: 'Description release'
+      changesNotSentForReview:
+        description: 'Play 업로드만 하고 review 자동 제출은 생략 (정책 거부로 자동 전송 막힐 때 true)'
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: write
@@ -149,5 +154,5 @@ jobs:
           releaseName: ${{ env.RELEASE }}
           tracks: internal
           status: completed
-          changesNotSentForReview: true
+          changesNotSentForReview: ${{ github.event.inputs.changesNotSentForReview }}
           mappingFile: app/build/outputs/mapping/playstoreRelease/mapping.txt

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -11,11 +11,11 @@ on:
         description: 'Release description'
         required: true
         default: 'Description release'
-      changesNotSentForReview:
-        description: 'Play 업로드만 하고 review 자동 제출은 생략 (정책 거부로 자동 전송 막힐 때 true)'
+      submitForReview:
+        description: 'Play Console 자동 제출'
         type: boolean
         required: false
-        default: false
+        default: true
 
 permissions:
   contents: write
@@ -154,5 +154,5 @@ jobs:
           releaseName: ${{ env.RELEASE }}
           tracks: internal
           status: completed
-          changesNotSentForReview: ${{ github.event.inputs.changesNotSentForReview }}
+          changesNotSentForReview: ${{ github.event.inputs.submitForReview != 'true' }}
           mappingFile: app/build/outputs/mapping/playstoreRelease/mapping.txt

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/AppUpdaterUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/AppUpdaterUtil.kt
@@ -106,7 +106,8 @@ object AppUpdaterUtil {
                         release = response.body()?.firstOrNull { it.isPreRelease != true }
                     }
                     val apkUrl = getLatestApkUrl(release)
-                    val releaseDescription = release?.let { "${it.tagName}\n${it.body}" }.orEmpty()
+                    val releaseDescription =
+                        release?.let { "${it.tagName}\n${extractDescription(it.body)}" }.orEmpty()
 
                     AlertDialog
                         .Builder(
@@ -366,4 +367,18 @@ object AppUpdaterUtil {
         } catch (e: PackageManager.NameNotFoundException) {
             false
         }
+
+    private val HTML_COMMENT_REGEX = Regex("(?s)<!--.*?-->")
+    private const val AUTO_NOTES_MARKER = "## What's Changed"
+
+    /**
+     * GitHub 릴리즈 본문에서 사용자 description 만 추려낸다.
+     * - HTML 주석 블록(`<!-- ... -->`) 제거 (신규 워크플로가 자동 노트를 여기 감싸 둠)
+     * - 그래도 남아있는 자동 생성 마커(`## What's Changed` 이후) 잘라냄 (구버전 릴리즈 호환)
+     */
+    internal fun extractDescription(body: String?): String {
+        if (body == null) return ""
+        val withoutComments = body.replace(HTML_COMMENT_REGEX, "")
+        return withoutComments.substringBefore(AUTO_NOTES_MARKER).trim()
+    }
 }

--- a/app/src/test/kotlin/me/zipi/navitotesla/util/AppUpdaterUtilStripCommentsTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/util/AppUpdaterUtilStripCommentsTest.kt
@@ -1,0 +1,59 @@
+package me.zipi.navitotesla.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AppUpdaterUtilStripCommentsTest {
+    @Test
+    fun `returns empty for null`() {
+        assertEquals("", AppUpdaterUtil.extractDescription(null))
+    }
+
+    @Test
+    fun `returns trimmed input when no comments and no auto-notes marker`() {
+        assertEquals("hello world", AppUpdaterUtil.extractDescription("  hello world  "))
+    }
+
+    @Test
+    fun `strips single-line HTML comment`() {
+        assertEquals("after", AppUpdaterUtil.extractDescription("<!-- hidden -->after"))
+    }
+
+    @Test
+    fun `strips multi-line HTML comment wrapping auto notes`() {
+        val input =
+            """
+            description
+
+            <!--
+            ## What's Changed
+            * feat: foo in #1
+            * fix: bar in #2
+            -->
+            """.trimIndent()
+        assertEquals("description", AppUpdaterUtil.extractDescription(input))
+    }
+
+    @Test
+    fun `truncates at auto-notes marker for legacy releases without comment wrap`() {
+        val input =
+            """
+            v1.95 changes
+            - fix: foo
+
+            ## What's Changed
+            * chore(deps): bump in #1
+            **Full Changelog**: ...
+            """.trimIndent()
+        assertEquals(
+            "v1.95 changes\n- fix: foo",
+            AppUpdaterUtil.extractDescription(input),
+        )
+    }
+
+    @Test
+    fun `strips multiple HTML comments`() {
+        val input = "<!-- a -->visible<!-- b -->"
+        assertEquals("visible", AppUpdaterUtil.extractDescription(input))
+    }
+}


### PR DESCRIPTION
## Summary
1. 앱의 업데이트 다이얼로그가 사용자가 입력한 description 만 노출하도록 수정
2. 직전 런(#26011097064) 에서 Play Console 업로드 실패한 원인 대응

## 앱 변경
- `AppUpdaterUtil.extractDescription()` 도입
  - `<!-- ... -->` HTML 주석 블록 제거 (이번 워크플로가 자동 노트를 여기 감싸 둠)
  - 그래도 남아있는 `## What's Changed` 마커 이후 잘라냄 (구버전 릴리즈 호환)
- 사용자가 대부분 업데이트한 후 다시 자동 노트를 표시할 계획. 그때까진 description 만 보임.

## CI 변경
- Play 업로드 단계가 `Changes cannot be sent for review automatically` 로 실패. `changesNotSentForReview: true` 추가
- `track: internal` (deprecated) → `tracks: internal` 로 마이그레이션

## Test plan
- [x] 신규/구버전 릴리즈 본문 모두 description 만 추출되는지 테스트 (5 케이스)
- [ ] 다음 dispatch 시 Play 업로드 성공 확인