### PR TITLE
fix: Android 14+ ShareWorker FGS 누락으로 목적지 전송 실패 + 로그 통합

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SHORT_SERVICE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.BLUETOOTH"
         android:maxSdkVersion="30" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SHORT_SERVICE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.BLUETOOTH"
         android:maxSdkVersion="30" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <application
         android:name=".Application"
         android:allowBackup="false"
+        android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher"

--- a/app/src/main/kotlin/me/zipi/navitotesla/background/ShareWorker.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/background/ShareWorker.kt
@@ -5,6 +5,7 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
+import android.content.pm.ServiceInfo
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.work.Constraints
@@ -31,7 +32,18 @@ class ShareWorker(
         if (AppRepository.isInitialized()) NaviToTeslaService(context) else null
     private val channelId = "location_share_channel"
 
-    override suspend fun getForegroundInfo(): ForegroundInfo = ForegroundInfo(1, createNotification())
+    override suspend fun getForegroundInfo(): ForegroundInfo =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            // Android 14 (API 34) 부터는 ForegroundInfo 에 서비스 타입 필수.
+            // 짧은 작업(목적지 1회 전송) 이라 SHORT_SERVICE 가 적합.
+            ForegroundInfo(
+                1,
+                createNotification(),
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE,
+            )
+        } else {
+            ForegroundInfo(1, createNotification())
+        }
 
     override suspend fun doWork(): Result {
         if (naviToTeslaService == null) {

--- a/app/src/main/kotlin/me/zipi/navitotesla/background/TokenWorker.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/background/TokenWorker.kt
@@ -1,7 +1,6 @@
 package me.zipi.navitotesla.background
 
 import android.content.Context
-import android.util.Log
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingPeriodicWorkPolicy
@@ -20,7 +19,6 @@ class TokenWorker(
     workerParams: WorkerParameters,
 ) : CoroutineWorker(context, workerParams) {
     override suspend fun doWork(): Result {
-        Log.i(TokenWorker::class.java.name, "Start background refresh token")
         AnalysisUtil.log("Start background refresh token")
         val service = NaviToTeslaService(applicationContext)
         val token = service.refreshToken()

--- a/app/src/main/kotlin/me/zipi/navitotesla/receiver/NotificationListener.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/receiver/NotificationListener.kt
@@ -4,7 +4,6 @@ import android.app.Notification
 import android.os.Bundle
 import android.service.notification.NotificationListenerService
 import android.service.notification.StatusBarNotification
-import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.google.firebase.analytics.FirebaseAnalytics
 import kotlinx.coroutines.CoroutineScope
@@ -39,11 +38,7 @@ class NotificationListener : NotificationListenerService() {
     override fun onNotificationRemoved(sbn: StatusBarNotification) {
         super.onNotificationRemoved(sbn)
         if (PoiFinderFactory.isNaviSupport(sbn.packageName)) {
-            Log.i(
-                this.javaClass.name,
-                "onNotificationRemoved ~ " +
-                    " packageName: " + sbn.packageName,
-            )
+            AnalysisUtil.log("onNotificationRemoved ~ packageName: ${sbn.packageName}")
             serviceScope.launch { naviToTeslaService.notificationClear() }
             val param = Bundle()
             param.putString("package", sbn.packageName)
@@ -61,16 +56,10 @@ class NotificationListener : NotificationListenerService() {
                 val subText = extras.getString(Notification.EXTRA_SUB_TEXT) ?: ""
                 val bigText = extras.getCharSequence(Notification.EXTRA_BIG_TEXT)?.toString() ?: ""
 
-                Log.i(
-                    this.javaClass.name,
-                    "onNotificationPosted ~ " +
-                        " packageName: " + sbn.packageName +
-                        " id: " + sbn.id +
-                        " postTime: " + sbn.postTime +
-                        " title: " + title +
-                        " text : " + text +
-                        " subText: " + subText +
-                        " bigText: " + bigText,
+                AnalysisUtil.log(
+                    "onNotificationPosted ~ packageName: ${sbn.packageName} " +
+                        "id: ${sbn.id} postTime: ${sbn.postTime} title: $title " +
+                        "text: $text subText: $subText bigText: $bigText",
                 )
 
                 val bundle = Bundle()

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/NaviToTeslaService.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/NaviToTeslaService.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
-import android.util.Log
 import android.widget.Toast
 import com.google.firebase.perf.metrics.AddTrace
 import me.zipi.navitotesla.AppRepository
@@ -40,7 +39,6 @@ class NaviToTeslaService(
 
     private fun makeToast(text: String) {
         try {
-            Log.i(this.javaClass.name, text)
             AnalysisUtil.log(text)
             Handler(Looper.getMainLooper()).post {
                 Toast.makeText(context, text, Toast.LENGTH_LONG).show()
@@ -122,7 +120,7 @@ class NaviToTeslaService(
             AnalysisUtil.logEvent("error_share", eventParam)
             AnalysisUtil.recordException(e)
         } catch (e: Exception) {
-            Log.e(NaviToTeslaService::class.java.name, "thread inside error", e)
+            AnalysisUtil.error("thread inside error", e)
             makeToast(context.getString(R.string.sendDestinationFail) + "\n" + context.getString(R.string.apiError))
             AnalysisUtil.logEvent("error_share", eventParam)
             AnalysisUtil.recordException(e)
@@ -252,7 +250,7 @@ class NaviToTeslaService(
             }
             ResponseCloser.closeAll(newToken)
         } catch (e: Exception) {
-            Log.w(this.javaClass.name, "refresh token fail", e)
+            AnalysisUtil.warn("refresh token fail", e)
             makeToast(context.getString(R.string.refreshTokenError))
             AnalysisUtil.recordException(e)
         }
@@ -294,10 +292,10 @@ class NaviToTeslaService(
                         )
                     }?.let { vehicles.addAll(it) }
             } else {
-                Log.w(this.javaClass.name, "get vehicle error: $response")
+                AnalysisUtil.warn("get vehicle error: $response")
             }
         } catch (e: Exception) {
-            Log.w(this.javaClass.name, "get vehicle error", e)
+            AnalysisUtil.warn("get vehicle error", e)
             AnalysisUtil.recordException(e)
         }
         if (vehicles.isEmpty()) {

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/KakaoPoiFinder.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/KakaoPoiFinder.kt
@@ -1,6 +1,5 @@
 package me.zipi.navitotesla.service.poifinder
 
-import android.util.Log
 import me.zipi.navitotesla.api.KakaoMapApi
 import me.zipi.navitotesla.model.Poi
 import me.zipi.navitotesla.util.AnalysisUtil
@@ -27,8 +26,7 @@ class KakaoPoiFinder : PoiFinder {
         val poiList = mutableListOf<Poi>()
         val response = kakaoMapApi.search(poiName)
         if (!response.isSuccessful || response.body() == null) {
-            Log.w(this.javaClass.name, "Kakao api error: " + response.errorBody())
-            AnalysisUtil.log("Kakao api error: " + response.errorBody()?.string().orEmpty())
+            AnalysisUtil.warn("Kakao api error: " + response.errorBody()?.string().orEmpty())
         }
         response.body()?.let { body ->
             val withLocalName = RemoteConfigUtil.getBoolean("withLocalName") // 법정동 포함 여부

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/NaverPoiFinder.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/NaverPoiFinder.kt
@@ -1,6 +1,5 @@
 package me.zipi.navitotesla.service.poifinder
 
-import android.util.Log
 import me.zipi.navitotesla.api.NaverFusionSearchApi
 import me.zipi.navitotesla.api.NaverMapApi
 import me.zipi.navitotesla.model.Poi
@@ -40,8 +39,7 @@ class NaverPoiFinder : PoiFinder {
         val poiList = mutableListOf<Poi>()
         val response = naverMapApi.search(poiName)
         if (!response.isSuccessful || response.body() == null) {
-            Log.w(this.javaClass.name, "naver api error: " + response.errorBody()?.string().orEmpty())
-            AnalysisUtil.log("naver api error: " + response.errorBody()?.string().orEmpty())
+            AnalysisUtil.warn("naver api error: " + response.errorBody()?.string().orEmpty())
         }
         response.body()?.items?.let { items ->
             val withLocalName = RemoteConfigUtil.getBoolean("withLocalName")
@@ -65,8 +63,7 @@ class NaverPoiFinder : PoiFinder {
         val poiList = mutableListOf<Poi>()
         val response = naverFusionSearchApi.search(poiName)
         if (!response.isSuccessful || response.body() == null) {
-            Log.w(this.javaClass.name, "naver fusion search error: " + response.errorBody()?.string().orEmpty())
-            AnalysisUtil.log("naver fusion search error: " + response.errorBody()?.string().orEmpty())
+            AnalysisUtil.warn("naver fusion search error: " + response.errorBody()?.string().orEmpty())
         }
         response.body()?.items?.let { items ->
             val withLocalName = RemoteConfigUtil.getBoolean("withLocalName")

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/TMapPoiFinder.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/TMapPoiFinder.kt
@@ -1,6 +1,5 @@
 package me.zipi.navitotesla.service.poifinder
 
-import android.util.Log
 import me.zipi.navitotesla.api.TMapApi
 import me.zipi.navitotesla.model.Poi
 import me.zipi.navitotesla.util.AnalysisUtil
@@ -33,8 +32,7 @@ class TMapPoiFinder : PoiFinder {
         val listPoi = mutableListOf<Poi>()
         val response = tMapApi.search(poiName)
         if (!response.isSuccessful || response.body() == null) {
-            Log.w(this.javaClass.name, "Tmap api error: " + response.errorBody())
-            AnalysisUtil.log("Tmap api error: " + response.errorBody()?.string().orEmpty())
+            AnalysisUtil.warn("Tmap api error: " + response.errorBody()?.string().orEmpty())
         }
         if (response.isSuccessful && response.body()?.searchPoiInfo != null) {
             val withLocalName = RemoteConfigUtil.getBoolean("withLocalName") // 법정동 포함 여부

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/share/TeslaShareByApi.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/share/TeslaShareByApi.kt
@@ -1,7 +1,6 @@
 package me.zipi.navitotesla.service.share
 
 import android.content.Context
-import android.util.Log
 import kotlinx.coroutines.delay
 import me.zipi.navitotesla.AppRepository
 import me.zipi.navitotesla.BuildConfig
@@ -41,7 +40,7 @@ class TeslaShareByApi(
             AnalysisUtil.log("send_success")
             AnalysisUtil.logEvent("share_by_api_success", eventParam(poi))
         } else {
-            Log.w(NaviToTeslaService::class.java.name, response.toString())
+            AnalysisUtil.warn(response.toString())
             AnalysisUtil.makeToast(context, context.getString(R.string.sendDestinationFail) + (result?.errorDescription ?: ""))
 
             AnalysisUtil.log("send_fail")

--- a/app/src/main/kotlin/me/zipi/navitotesla/ui/home/HomeFragment.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/ui/home/HomeFragment.kt
@@ -12,7 +12,6 @@ import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import android.text.method.ScrollingMovementMethod
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -265,7 +264,7 @@ class HomeFragment :
             if (homeViewModel.refreshToken.value != token.refreshToken || homeViewModel.vehicleListLiveData.value.isNullOrEmpty()) {
                 homeViewModel.refreshToken.postValue(token.refreshToken)
             } else {
-                Log.i(this.javaClass.name, "skip refresh token fetch, token unchanged and vehicles loaded")
+                AnalysisUtil.log("skip refresh token fetch, token unchanged and vehicles loaded")
             }
         }
     }
@@ -287,7 +286,7 @@ class HomeFragment :
                 PreferencesUtil.put("denyNotificationPermission", false)
                 PreferencesUtil.put("denyFilePermission", false)
             } catch (e: Exception) {
-                Log.w(this.javaClass.name, "clear poi cache error", e)
+                AnalysisUtil.warn("clear poi cache error", e)
                 AnalysisUtil.recordException(e)
             }
             if (activity != null) {
@@ -383,7 +382,7 @@ class HomeFragment :
                 withContext(Dispatchers.Main) {
                     binding.btnSave.isEnabled = true
                 }
-                Log.e(this.javaClass.name, "thread inside error", e)
+                AnalysisUtil.error("thread inside error", e)
                 AnalysisUtil.recordException(e)
             }
         }

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/AnalysisUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/AnalysisUtil.kt
@@ -51,13 +51,24 @@ object AnalysisUtil {
         appendLog("INFO", message)
     }
 
-    fun warn(message: String) {
-        appendLog("WARN", message)
+    fun warn(
+        message: String,
+        e: Throwable? = null,
+    ) {
+        appendLog("WARN", withStack(message, e))
     }
 
-    fun error(message: String) {
-        appendLog("ERROR", message)
+    fun error(
+        message: String,
+        e: Throwable? = null,
+    ) {
+        appendLog("ERROR", withStack(message, e))
     }
+
+    private fun withStack(
+        message: String,
+        e: Throwable?,
+    ): String = if (e == null) message else "$message${System.lineSeparator()}${e.stackTraceToString()}"
 
     fun report(message: String) {
         firebaseCrashlytics.log(message)

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/AppUpdaterUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/AppUpdaterUtil.kt
@@ -12,7 +12,6 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
-import android.util.Log
 import androidx.appcompat.app.AlertDialog
 import androidx.core.app.NotificationCompat
 import androidx.core.net.toUri
@@ -137,13 +136,12 @@ object AppUpdaterUtil {
                     dialogLastCheck = System.currentTimeMillis()
                     ResponseCloser.closeAll(response)
                 } catch (e: Exception) {
-                    Log.w(AppUpdaterUtil::class.java.name, "error update dialog show", e)
-                    AnalysisUtil.log("fail update")
+                    AnalysisUtil.warn("error update dialog show", e)
                     AnalysisUtil.recordException(e)
                 }
             }
         } catch (e: NullPointerException) {
-            Log.w(AppUpdaterUtil::class.java.name, "activity is null", e)
+            AnalysisUtil.warn("activity is null", e)
         }
     }
 
@@ -207,8 +205,7 @@ object AppUpdaterUtil {
             }
             clearDoNotShow()
         } catch (e: Exception) {
-            Log.w(AppUpdaterUtil::class.java.name, "fail update")
-            AnalysisUtil.log("fail update")
+            AnalysisUtil.warn("fail update", e)
             AnalysisUtil.recordException(e)
         }
     }
@@ -239,7 +236,7 @@ object AppUpdaterUtil {
                     ]
                 }
             } catch (e: Exception) {
-                Log.w(AppUpdaterUtil::class.java.name, "getLatestVersion fail", e)
+                AnalysisUtil.warn("getLatestVersion fail", e)
                 AnalysisUtil.recordException(e)
             }
             return@withContext "1.0"

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/PreferencesUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/PreferencesUtil.kt
@@ -2,7 +2,6 @@ package me.zipi.navitotesla.util
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.util.Log
 import androidx.core.content.edit
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
@@ -44,7 +43,7 @@ object PreferencesUtil {
                 instance.edit { remove(key) }
                 true
             } catch (e: Exception) {
-                Log.w(PreferencesUtil::class.java.name, "remove  error", e)
+                AnalysisUtil.warn("remove  error", e)
                 AnalysisUtil.recordException(e)
                 false
             }
@@ -55,7 +54,7 @@ object PreferencesUtil {
             try {
                 instance.edit { clear() }
             } catch (e: Exception) {
-                Log.w(PreferencesUtil::class.java.name, "clear error", e)
+                AnalysisUtil.warn("clear error", e)
                 AnalysisUtil.recordException(e)
             }
         }
@@ -70,7 +69,7 @@ object PreferencesUtil {
                 instance.edit { putBoolean(key, value) }
                 true
             } catch (e: Exception) {
-                Log.w(PreferencesUtil::class.java.name, "put boolean error", e)
+                AnalysisUtil.warn("put boolean error", e)
                 AnalysisUtil.recordException(e)
                 false
             }
@@ -85,7 +84,7 @@ object PreferencesUtil {
                 instance.edit { putLong(key, value) }
                 true
             } catch (e: Exception) {
-                Log.w(PreferencesUtil::class.java.name, "put long error", e)
+                AnalysisUtil.warn("put long error", e)
                 AnalysisUtil.recordException(e)
                 false
             }
@@ -100,7 +99,7 @@ object PreferencesUtil {
                 instance.edit { putString(key, value) }
                 true
             } catch (e: Exception) {
-                Log.w(PreferencesUtil::class.java.name, "put string error", e)
+                AnalysisUtil.warn("put string error", e)
                 AnalysisUtil.recordException(e)
                 false
             }
@@ -114,7 +113,7 @@ object PreferencesUtil {
             try {
                 instance.getString(key, defaultValue)
             } catch (e: Exception) {
-                Log.w(PreferencesUtil::class.java.name, "get string error", e)
+                AnalysisUtil.warn("get string error", e)
                 AnalysisUtil.recordException(e)
                 defaultValue
             }
@@ -127,7 +126,7 @@ object PreferencesUtil {
         try {
             instance.getString(key, defaultValue)
         } catch (e: Exception) {
-            Log.w(PreferencesUtil::class.java.name, "get string error", e)
+            AnalysisUtil.warn("get string error", e)
             AnalysisUtil.recordException(e)
             defaultValue
         }
@@ -146,7 +145,7 @@ object PreferencesUtil {
             try {
                 instance.getBoolean(key, defaultValue)
             } catch (e: Exception) {
-                Log.w(PreferencesUtil::class.java.name, "get boolean error", e)
+                AnalysisUtil.warn("get boolean error", e)
                 AnalysisUtil.recordException(e)
                 defaultValue
             }
@@ -158,7 +157,7 @@ object PreferencesUtil {
                 val result = instance.getLong(key, -1)
                 if (result == -1L) null else result
             } catch (e: Exception) {
-                Log.w(PreferencesUtil::class.java.name, "get long error", e)
+                AnalysisUtil.warn("get long error", e)
                 AnalysisUtil.recordException(e)
                 null
             }
@@ -169,7 +168,7 @@ object PreferencesUtil {
             val result = instance.getLong(key, -1)
             if (result == -1L) null else result
         } catch (e: Exception) {
-            Log.w(PreferencesUtil::class.java.name, "get long error", e)
+            AnalysisUtil.warn("get long error", e)
             AnalysisUtil.recordException(e)
             null
         }
@@ -182,7 +181,7 @@ object PreferencesUtil {
             try {
                 instance.getLong(key, defaultValue)
             } catch (e: Exception) {
-                Log.w(PreferencesUtil::class.java.name, "get long error", e)
+                AnalysisUtil.warn("get long error", e)
                 AnalysisUtil.recordException(e)
                 defaultValue
             }

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/RemoteConfigUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/RemoteConfigUtil.kt
@@ -1,6 +1,5 @@
 package me.zipi.navitotesla.util
 
-import android.util.Log
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
@@ -21,7 +20,7 @@ object RemoteConfigUtil {
         remoteConfig.setConfigSettingsAsync(configSettings)
         remoteConfig.setDefaultsAsync(R.xml.remote_config_defaults)
         remoteConfig.fetchAndActivate().addOnCompleteListener {
-            Log.i(RemoteConfigUtil::class.java.name, "Remote config fetch ok")
+            AnalysisUtil.log("Remote config fetch ok")
         }
     }
 

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/ResponseCloser.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/ResponseCloser.kt
@@ -1,6 +1,5 @@
 package me.zipi.navitotesla.util
 
-import android.util.Log
 import retrofit2.Response
 
 object ResponseCloser {
@@ -14,8 +13,7 @@ object ResponseCloser {
             response.raw().body.close()
         } catch (_: IllegalStateException) {
         } catch (e: Exception) {
-            Log.w(ResponseCloser::class.java.name, "Http response close error", e)
-            AnalysisUtil.log("Http response close error")
+            AnalysisUtil.warn("Http response close error", e)
             AnalysisUtil.recordException(e)
         }
     }
@@ -24,8 +22,7 @@ object ResponseCloser {
         try {
             response.errorBody()?.close()
         } catch (e: Exception) {
-            Log.w(ResponseCloser::class.java.name, "Http response close error", e)
-            AnalysisUtil.log("Http response close error")
+            AnalysisUtil.warn("Http response close error", e)
             AnalysisUtil.recordException(e)
         }
     }


### PR DESCRIPTION
## Summary

### 핵심 수정 — Android 14+ 에서 목적지 전송이 안 됐던 문제
`ShareWorker.setExpedited` 가 quota 초과·timeout 시 foreground service 로 promote 시도하는데, manifest 에 `FOREGROUND_SERVICE` 권한과 `ForegroundInfo` 의 타입이 없어 Android 14 (API 34) 부터 무음 실패. TMap/Kakao 안내 시작해도 토스트도 안 뜨고 Tesla 전송도 안 됨.

- `AndroidManifest.xml`: `FOREGROUND_SERVICE` 권한 추가
- `ShareWorker.getForegroundInfo()`: API 34+ 에서 `FOREGROUND_SERVICE_TYPE_SHORT_SERVICE` 지정

→ Android 14·15·16 디바이스 전부 한 fix 로 복구.

### 부수 — Log → AnalysisUtil 통합
모든 `android.util.Log.i/w/e` 호출을 `AnalysisUtil.log/warn/error` 로 통합 → 로컬 로그 파일에 노티 수신·워커 실행 흐름이 그대로 남도록. 사용자가 "안내 안 됨" 증상 보고 시 로그 파일 한 번에 원인 추적 가능.

- `AnalysisUtil.warn/error` 가 `Throwable` 옵션 인자 받도록 확장
- 12개 파일에서 `Log.*` 호출 마이그레이션
- 미사용 `android.util.Log` import 정리

### 추가 — Android 16 권장사항
- `<application android:enableOnBackInvokedCallback="true">` 추가 → Predictive Back Gesture 옵트인, `OnBackInvokedCallback is not enabled` 경고 해소

## 커밋
- `ebf6d3b` Android 14+ FGS 타입 누락 수정 (핵심)
- `eaee3d3` Log → AnalysisUtil 통합 (진단성)
- `cd78670` 존재하지 않는 SHORT_SERVICE 권한 제거
- `bb2555d` Predictive Back Gesture 옵트인

## Test plan
- [x] `:app:compilePlaystoreDebugKotlin` / `:app:compileNostoreDebugKotlin` / `:app:testPlaystoreDebugUnitTest` 통과
- [ ] Android 14/15/16 디바이스에서 TMap 안내 시작 → Tesla 전송 동작 확인
- [ ] 로그 파일에 `onNotificationPosted ~ ...` + `Register share worker` + `Start share worker` 흐름이 남는지 확인

## 미해결 / 후속 작업
- Edge-to-edge 처리 (API 36 권장) — 시각 회귀 가능성 있어 별도 PR 분리 권장
- ShareWorker timeout 콜백 처리 — 실제 timeout 도달 거의 없을 듯, 후순위