### PR TITLE
fix: WorkManager FGS 서비스에 shortService 타입 명시

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
@@ -60,6 +61,11 @@
                 android:name="android.accessibilityservice"
                 android:resource="@xml/accessibility_config" />
         </service>
+
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="shortService"
+            tools:node="merge" />
 
         <receiver android:name=".receiver.BluetoothReceiver"
             android:exported="true">


### PR DESCRIPTION
## Summary
Android Studio lint 경고 "Android 14+ requires Foreground Service types declaration and justification" 해소.

PR #367 에서 `ShareWorker.getForegroundInfo()` 에 type 을 지정했지만, **manifest 의 `<service>` 선언에도 동일한 type 이 포함돼 있어야** Android 14+ 정책 충족. WorkManager 가 제공하는 `androidx.work.impl.foreground.SystemForegroundService` 는 라이브러리 manifest 에 type 없이 선언되어 있어, 우리 manifest 에서 `tools:node="merge"` 로 보강.

## 변경
- `AndroidManifest.xml` 에 `tools` namespace 추가
- WorkManager 의 `SystemForegroundService` 에 `android:foregroundServiceType="shortService"` merge

## 검증
- merged manifest 출력 확인: `SystemForegroundService` 에 `android:foregroundServiceType="shortService"` 정상 결합
- `:app:assemblePlaystoreDebug` / `:app:testPlaystoreDebugUnitTest` 통과

## Test plan
- [ ] Android Studio lint 패널에서 FGS type 경고 사라짐
- [ ] Android 14+ 디바이스에서 TMap 안내 동작 (PR #367 효과와 결합)