### PR TITLE
fix: Crashlytics 활성 버그 수정

### DIFF
--- a/app/src/main/kotlin/me/zipi/navitotesla/Application.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/Application.kt
@@ -24,9 +24,9 @@ class Application : Application() {
             "App started: v${BuildConfig.VERSION_NAME} (${BuildConfig.BUILD_MODE}, " +
                 "sdk=${Build.VERSION.SDK_INT}, device=${Build.MANUFACTURER} ${Build.MODEL})",
         )
+        FirebaseCrashlytics.getInstance().isCrashlyticsCollectionEnabled = !BuildConfig.DEBUG
         if (!BuildConfig.DEBUG) {
             CoroutineScope(Dispatchers.IO).launch { TokenWorker.startBackgroundWork(this@Application) }
-            FirebaseCrashlytics.getInstance().isCrashlyticsCollectionEnabled = false
         }
     }
 


### PR DESCRIPTION
## Summary
2022-01-12 의 코드 정리 (`b4cdf52`) 에서 의도와 다르게 의미가 뒤집힌 부분 복원.

## 변경 이력
- 2021-12-30 (`b11897f`) **정상 패턴 도입**: `setCrashlyticsCollectionEnabled(!BuildConfig.DEBUG)`
- 2022-01-12 (`b4cdf52`) **의도치 않은 flip**: `if (!DEBUG) { ... setEnabled(false) }` → release 에서 꺼지고 debug 에서 (기본값) 켜짐
- 이후 4년간 유지

## 의도된 동작
| 빌드 | TokenWorker | Crashlytics |
|------|-------------|-------------|
| debug | ❌ 안 실행 | ❌ 꺼짐 (개발 중 외부 전송 없음) |
| release | ✓ 실행 | ✓ 켜짐 (운영 크래시 수집) |

## 변경
```diff
-        if (!BuildConfig.DEBUG) {
-            CoroutineScope(Dispatchers.IO).launch { TokenWorker.startBackgroundWork(this@Application) }
-            FirebaseCrashlytics.getInstance().isCrashlyticsCollectionEnabled = false
-        }
+        FirebaseCrashlytics.getInstance().isCrashlyticsCollectionEnabled = !BuildConfig.DEBUG
+        if (!BuildConfig.DEBUG) {
+            CoroutineScope(Dispatchers.IO).launch { TokenWorker.startBackgroundWork(this@Application) }
+        }
```

## 주의 — 운영 환경 영향
- 머지 후 release 빌드는 Crashlytics 데이터 수집 시작
- 이전 audit (H2) 에서 우려했던 `setCustomKey` 의 PII 전송 가능성이 *실제로 활성화됨*
- 현재 코드는 PII 키 (`notificationText`, `address`) 가 이미 제거됨 (#366 reflect) — 안전
- 남은 `setCustomKey`: `packageName`, `notificationTitle` (모두 비-PII)
- 남은 breadcrumb: `report()` 호출처 (PII 없는 진단용)
- Firebase 콘솔에서 production 크래시 다시 보기 시작

## Test plan
- [x] 컴파일 통과 (playstore/nostore debug)
- [ ] release 빌드 install 후 Firebase Crashlytics 대시보드에 신규 세션 보임 확인
- [ ] debug 빌드 install 시 Crashlytics 콜렉션 비활성 동작 확인