### PR TITLE
feat: Firestore 기반 자동완성 결과 cache

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -91,6 +91,7 @@ kotlin {
 
 dependencies {
     implementation(libs.kotlin.coroutine)
+    implementation(libs.kotlinx.coroutines.play.services)
 
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
@@ -118,6 +119,9 @@ dependencies {
 
     implementation(platform(libs.firebase.bom))
     implementation(libs.bundles.firebase)
+    debugImplementation(libs.firebase.appcheck.debug)
+
+    implementation(libs.google.places)
 
     testImplementation(libs.junit)
     testImplementation(libs.androidx.test.core)

--- a/app/schemas/me.zipi.navitotesla.db.AppDatabase/7.json
+++ b/app/schemas/me.zipi.navitotesla.db.AppDatabase/7.json
@@ -1,0 +1,190 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 7,
+    "identityHash": "6457a67ff255e3cb3bdfc84e603cbaeb",
+    "entities": [
+      {
+        "tableName": "poi_address",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `poi` TEXT NOT NULL, `address` TEXT NOT NULL, `longitude` TEXT, `latitude` TEXT, `registered` INTEGER, `created` INTEGER, `packageName` TEXT, `isDuplicate` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "poi",
+            "columnName": "poi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "registered",
+            "columnName": "registered",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isDuplicate",
+            "columnName": "isDuplicate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_poi_address_poi_packageName",
+            "unique": true,
+            "columnNames": [
+              "poi",
+              "packageName"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_poi_address_poi_packageName` ON `${TABLE_NAME}` (`poi`, `packageName`)"
+          }
+        ]
+      },
+      {
+        "tableName": "condition",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `created` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_condition_type_name",
+            "unique": true,
+            "columnNames": [
+              "type",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_condition_type_name` ON `${TABLE_NAME}` (`type`, `name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "destination_send_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `poi` TEXT NOT NULL, `sentAddress` TEXT NOT NULL, `sentAsJibun` INTEGER NOT NULL, `packageName` TEXT NOT NULL, `created` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "poi",
+            "columnName": "poi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sentAddress",
+            "columnName": "sentAddress",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sentAsJibun",
+            "columnName": "sentAsJibun",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_destination_send_cache_poi_packageName",
+            "unique": true,
+            "columnNames": [
+              "poi",
+              "packageName"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_destination_send_cache_poi_packageName` ON `${TABLE_NAME}` (`poi`, `packageName`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6457a67ff255e3cb3bdfc84e603cbaeb')"
+    ]
+  }
+}

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <receiver
+            android:name=".receiver.DebugTriggerReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="me.zipi.navitotesla.DEBUG_TRIGGER" />
+            </intent-filter>
+        </receiver>
+    </application>
+</manifest>

--- a/app/src/debug/kotlin/me/zipi/navitotesla/receiver/DebugTriggerReceiver.kt
+++ b/app/src/debug/kotlin/me/zipi/navitotesla/receiver/DebugTriggerReceiver.kt
@@ -1,0 +1,26 @@
+package me.zipi.navitotesla.receiver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import me.zipi.navitotesla.background.ShareWorker
+
+/**
+ * ADB 로 알림을 시뮬레이션하는 debug 전용 receiver. release 빌드에는 포함되지 않음.
+ *
+ *   adb shell "am broadcast -a me.zipi.navitotesla.DEBUG_TRIGGER \
+ *       --es pkg 'com.skt.tmap.ku' --es title '경로주행' --es text '내 위치 > 강남역' \
+ *       -p me.zipi.navitotesla.ns.debug"
+ */
+class DebugTriggerReceiver : BroadcastReceiver() {
+    override fun onReceive(
+        context: Context,
+        intent: Intent,
+    ) {
+        val pkg = intent.getStringExtra("pkg")
+        val title = intent.getStringExtra("title")
+        val text = intent.getStringExtra("text")
+        if (pkg.isNullOrEmpty() || text.isNullOrEmpty()) return
+        ShareWorker.startShare(context.applicationContext, pkg, title, text)
+    }
+}

--- a/app/src/debug/kotlin/me/zipi/navitotesla/util/AppCheckUtil.kt
+++ b/app/src/debug/kotlin/me/zipi/navitotesla/util/AppCheckUtil.kt
@@ -1,0 +1,14 @@
+package me.zipi.navitotesla.util
+
+import com.google.firebase.appcheck.FirebaseAppCheck
+import com.google.firebase.appcheck.debug.DebugAppCheckProviderFactory
+import me.zipi.navitotesla.BuildConfig
+
+object AppCheckUtil {
+    fun initialize() {
+        if (BuildConfig.BUILD_MODE != "playstore") return
+        FirebaseAppCheck
+            .getInstance()
+            .installAppCheckProviderFactory(DebugAppCheckProviderFactory.getInstance())
+    }
+}

--- a/app/src/debug/kotlin/me/zipi/navitotesla/util/AppCheckUtil.kt
+++ b/app/src/debug/kotlin/me/zipi/navitotesla/util/AppCheckUtil.kt
@@ -2,11 +2,9 @@ package me.zipi.navitotesla.util
 
 import com.google.firebase.appcheck.FirebaseAppCheck
 import com.google.firebase.appcheck.debug.DebugAppCheckProviderFactory
-import me.zipi.navitotesla.BuildConfig
 
 object AppCheckUtil {
     fun initialize() {
-        if (BuildConfig.BUILD_MODE != "playstore") return
         FirebaseAppCheck
             .getInstance()
             .installAppCheckProviderFactory(DebugAppCheckProviderFactory.getInstance())

--- a/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
@@ -136,11 +136,8 @@ class AppRepository private constructor(
     }
 
     suspend fun clearExpiredDestinationSendCache() {
-        val expireDate =
-            (
-                System.currentTimeMillis() -
-                    DestinationSendCacheEntity.EXPIRE_DAY * 1000 * 60 * 60 * 24 * 1.2
-            ).toLong()
+        val ttlMs = DestinationSendCacheEntity.EXPIRE_DAY.toLong() * 1000L * 60L * 60L * 24L
+        val expireDate = (System.currentTimeMillis() - ttlMs * 12 / 10).toLong()
         database.destinationSendCacheDao().deleteExpired(expireDate)
     }
 

--- a/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
@@ -4,6 +4,7 @@ import androidx.room.withTransaction
 import me.zipi.navitotesla.api.TeslaApi
 import me.zipi.navitotesla.api.TeslaAuthApi
 import me.zipi.navitotesla.db.AppDatabase
+import me.zipi.navitotesla.db.DestinationSendCacheEntity
 import me.zipi.navitotesla.db.PoiAddressEntity
 import me.zipi.navitotesla.model.Poi
 import me.zipi.navitotesla.util.AnalysisUtil
@@ -132,6 +133,15 @@ class AppRepository private constructor(
                 database.poiAddressDao().delete(entity)
             }
         }
+    }
+
+    suspend fun clearExpiredDestinationSendCache() {
+        val expireDate =
+            (
+                System.currentTimeMillis() -
+                    DestinationSendCacheEntity.EXPIRE_DAY * 1000 * 60 * 60 * 24 * 1.2
+            ).toLong()
+        database.destinationSendCacheDao().deleteExpired(expireDate)
     }
 
     suspend fun clearAllPoi() {

--- a/app/src/main/kotlin/me/zipi/navitotesla/Application.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/Application.kt
@@ -1,7 +1,6 @@
 package me.zipi.navitotesla
 
 import android.app.Application
-import android.content.res.Configuration
 import android.os.Build
 import com.google.android.libraries.places.api.Places
 import com.google.firebase.crashlytics.FirebaseCrashlytics
@@ -10,6 +9,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import me.zipi.navitotesla.background.TokenWorker
 import me.zipi.navitotesla.db.AppDatabase
+import me.zipi.navitotesla.service.place.FirebaseAppCheckTokenProvider
 import me.zipi.navitotesla.service.place.PlacesAutocompleteClient
 import me.zipi.navitotesla.util.AnalysisUtil
 import me.zipi.navitotesla.util.AppCheckUtil
@@ -25,8 +25,7 @@ class Application : Application() {
         AppRepository.initialize(database)
         RemoteConfigUtil.initialize()
         AppCheckUtil.initialize()
-        if (BuildConfig.BUILD_MODE == "playstore") {
-            // RemoteConfigUtil.getString 이 Tasks.await 으로 main thread 를 차단할 수 있어 background 에서 수행.
+        if (BuildConfig.DEBUG || BuildConfig.BUILD_MODE == "playstore") {
             CoroutineScope(Dispatchers.IO).launch { initializePlacesSdk() }
         }
         AnalysisUtil.initialize(this.applicationContext)
@@ -45,16 +44,9 @@ class Application : Application() {
         if (placesKey.isEmpty() || placesKey == "default") return
         try {
             Places.initializeWithNewPlacesApiEnabled(this.applicationContext, placesKey, Locale.KOREA)
-            // Places SDK 응답 언어는 client context 의 locale 을 따른다. 디바이스 기본이 영어인 경우에도
-            // 한국어 결과를 받기 위해 KOREA locale context 로 client 생성.
-            val koreaConfig =
-                Configuration(this.applicationContext.resources.configuration).apply {
-                    setLocale(Locale.KOREA)
-                }
-            val koreaContext = this.applicationContext.createConfigurationContext(koreaConfig)
-            PlacesAutocompleteClient.setClient(Places.createClient(koreaContext))
+            Places.setPlacesAppCheckTokenProvider(FirebaseAppCheckTokenProvider())
+            PlacesAutocompleteClient.setClient(Places.createClient(this.applicationContext))
         } catch (e: Exception) {
-            AnalysisUtil.log("Places SDK init failed: ${e.javaClass.simpleName}")
             AnalysisUtil.recordException(e)
         }
     }

--- a/app/src/main/kotlin/me/zipi/navitotesla/Application.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/Application.kt
@@ -1,16 +1,21 @@
 package me.zipi.navitotesla
 
 import android.app.Application
+import android.content.res.Configuration
 import android.os.Build
+import com.google.android.libraries.places.api.Places
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import me.zipi.navitotesla.background.TokenWorker
 import me.zipi.navitotesla.db.AppDatabase
+import me.zipi.navitotesla.service.place.PlacesAutocompleteClient
 import me.zipi.navitotesla.util.AnalysisUtil
+import me.zipi.navitotesla.util.AppCheckUtil
 import me.zipi.navitotesla.util.PreferencesUtil
 import me.zipi.navitotesla.util.RemoteConfigUtil
+import java.util.Locale
 
 class Application : Application() {
     override fun onCreate() {
@@ -19,6 +24,11 @@ class Application : Application() {
         AppDatabase.initialize(this.applicationContext)
         AppRepository.initialize(database)
         RemoteConfigUtil.initialize()
+        AppCheckUtil.initialize()
+        if (BuildConfig.BUILD_MODE == "playstore") {
+            // RemoteConfigUtil.getString 이 Tasks.await 으로 main thread 를 차단할 수 있어 background 에서 수행.
+            CoroutineScope(Dispatchers.IO).launch { initializePlacesSdk() }
+        }
         AnalysisUtil.initialize(this.applicationContext)
         AnalysisUtil.log(
             "App started: v${BuildConfig.VERSION_NAME} (${BuildConfig.BUILD_MODE}, " +
@@ -27,6 +37,25 @@ class Application : Application() {
         FirebaseCrashlytics.getInstance().isCrashlyticsCollectionEnabled = !BuildConfig.DEBUG
         if (!BuildConfig.DEBUG) {
             CoroutineScope(Dispatchers.IO).launch { TokenWorker.startBackgroundWork(this@Application) }
+        }
+    }
+
+    private fun initializePlacesSdk() {
+        val placesKey = RemoteConfigUtil.getString(RemoteConfigUtil.KEY_GOOGLE_PLACES_API_KEY)
+        if (placesKey.isEmpty() || placesKey == "default") return
+        try {
+            Places.initializeWithNewPlacesApiEnabled(this.applicationContext, placesKey, Locale.KOREA)
+            // Places SDK 응답 언어는 client context 의 locale 을 따른다. 디바이스 기본이 영어인 경우에도
+            // 한국어 결과를 받기 위해 KOREA locale context 로 client 생성.
+            val koreaConfig =
+                Configuration(this.applicationContext.resources.configuration).apply {
+                    setLocale(Locale.KOREA)
+                }
+            val koreaContext = this.applicationContext.createConfigurationContext(koreaConfig)
+            PlacesAutocompleteClient.setClient(Places.createClient(koreaContext))
+        } catch (e: Exception) {
+            AnalysisUtil.log("Places SDK init failed: ${e.javaClass.simpleName}")
+            AnalysisUtil.recordException(e)
         }
     }
 

--- a/app/src/main/kotlin/me/zipi/navitotesla/db/AppDatabase.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/db/AppDatabase.kt
@@ -8,14 +8,15 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 
 @Database(
-    entities = [PoiAddressEntity::class, ConditionEntity::class],
-    version = 6,
+    entities = [PoiAddressEntity::class, ConditionEntity::class, DestinationSendCacheEntity::class],
+    version = 7,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
         AutoMigration(from = 3, to = 4),
         AutoMigration(from = 4, to = 5),
         AutoMigration(from = 5, to = 6),
+        AutoMigration(from = 6, to = 7),
     ],
 )
 @TypeConverters(DateConverter::class)
@@ -23,6 +24,8 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun poiAddressDao(): PoiAddressDao
 
     abstract fun conditionDao(): ConditionDao
+
+    abstract fun destinationSendCacheDao(): DestinationSendCacheDao
 
     companion object {
         private const val DATABASE_NAME = "data.sqlite"

--- a/app/src/main/kotlin/me/zipi/navitotesla/db/DestinationSendCacheDao.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/db/DestinationSendCacheDao.kt
@@ -1,0 +1,24 @@
+package me.zipi.navitotesla.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface DestinationSendCacheDao {
+    @Query(
+        "SELECT * FROM destination_send_cache " +
+            "WHERE poi = :poi AND packageName = :packageName LIMIT 1",
+    )
+    suspend fun find(
+        poi: String,
+        packageName: String,
+    ): DestinationSendCacheEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: DestinationSendCacheEntity)
+
+    @Query("DELETE FROM destination_send_cache WHERE created < :expireBefore")
+    suspend fun deleteExpired(expireBefore: Long)
+}

--- a/app/src/main/kotlin/me/zipi/navitotesla/db/DestinationSendCacheEntity.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/db/DestinationSendCacheEntity.kt
@@ -1,0 +1,31 @@
+package me.zipi.navitotesla.db
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.util.Date
+import kotlin.math.abs
+
+@Entity(
+    tableName = "destination_send_cache",
+    indices = [Index(value = ["poi", "packageName"], unique = true)],
+)
+class DestinationSendCacheEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Int? = null,
+    val poi: String,
+    val sentAddress: String,
+    val sentAsJibun: Boolean,
+    val packageName: String,
+    val created: Date,
+) {
+    val isExpire: Boolean
+        get() {
+            val ageInDays = abs(System.currentTimeMillis() - created.time) / 1000L / 60L / 60L / 24L
+            return ageInDays >= EXPIRE_DAY
+        }
+
+    companion object {
+        const val EXPIRE_DAY = 30
+    }
+}

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/NaviToTeslaService.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/NaviToTeslaService.kt
@@ -17,6 +17,7 @@ import me.zipi.navitotesla.model.TeslaApiResponse
 import me.zipi.navitotesla.model.TeslaRefreshTokenRequest
 import me.zipi.navitotesla.model.Token
 import me.zipi.navitotesla.model.Vehicle
+import me.zipi.navitotesla.service.place.DestinationAddressResolver
 import me.zipi.navitotesla.service.poifinder.PoiFinderFactory
 import me.zipi.navitotesla.service.share.TeslaShareByApi
 import me.zipi.navitotesla.service.share.TeslaShareByApp
@@ -89,6 +90,7 @@ class NaviToTeslaService(
                 AnalysisUtil.logEvent("previous_request_address", eventParam)
             }
             appRepository.clearExpiredPoi()
+            appRepository.clearExpiredDestinationSendCache()
         } catch (e: DuplicatePoiException) {
             AnalysisUtil.logEvent("duplicated_address", eventParam)
             AnalysisUtil.log("duplicate poi name: " + e.poiName)
@@ -130,6 +132,15 @@ class NaviToTeslaService(
 
     @Throws(IOException::class, ForbiddenException::class)
     suspend fun share(poi: Poi) {
+        val resolvedPoi =
+            if (poi.isAddressEmpty()) {
+                poi
+            } else {
+                val finalAddress = DestinationAddressResolver.resolve(poi)
+                poi.copy(roadAddress = finalAddress)
+            }
+        // 외부 share() 의 duplicate 가드는 navi 원본 도로명(`poi.getRoadAddress()`)을 비교한다.
+        // resolver 가 구주소로 바꿔 보냈더라도 lastAddress 에는 원본 도로명을 저장해 가드 정합성을 유지.
         PreferencesUtil.put(
             key = "lastAddress",
             value =
@@ -139,21 +150,21 @@ class NaviToTeslaService(
                     poi.getRoadAddress()
                 },
         )
-        if (!poi.isAddressEmpty()) {
+        if (!resolvedPoi.isAddressEmpty()) {
             lastShareAt = System.currentTimeMillis()
-            makeToast(context.getString(R.string.requestSend) + "\n" + poi.getRoadAddress())
+            makeToast(context.getString(R.string.requestSend) + "\n" + resolvedPoi.getRoadAddress())
             val shareMode = PreferencesUtil.getString("shareMode", "app")
             if (shareMode == "api" && PreferencesUtil.loadToken() != null) {
                 if (refreshToken() == null) {
                     return
                 }
                 val id = loadVehicleId()
-                TeslaShareByApi(context, id).share(poi)
+                TeslaShareByApi(context, id).share(resolvedPoi)
             } else {
-                TeslaShareByApp(context).share(poi)
+                TeslaShareByApp(context).share(resolvedPoi)
             }
         } else {
-            AnalysisUtil.log("share skipped: empty poi name=${poi.poiName}, pkg=${poi.packageName}")
+            AnalysisUtil.log("share skipped: empty poi name=${resolvedPoi.poiName}, pkg=${resolvedPoi.packageName}")
             makeToast(
                 context.getString(R.string.sendDestinationFail) + "\n" + context.getString(R.string.addressNotFound),
             )

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
@@ -1,0 +1,116 @@
+package me.zipi.navitotesla.service.place
+
+import kotlinx.coroutines.CancellationException
+import me.zipi.navitotesla.BuildConfig
+import me.zipi.navitotesla.db.AppDatabase
+import me.zipi.navitotesla.db.DestinationSendCacheEntity
+import me.zipi.navitotesla.model.Poi
+import me.zipi.navitotesla.util.AnalysisUtil
+import me.zipi.navitotesla.util.RemoteConfigUtil
+import java.util.Date
+
+object DestinationAddressResolver {
+    @Volatile
+    var matcher: PlaceAutocompleteMatcher = RealPlaceAutocompleteMatcher()
+
+    @Volatile
+    var cacheClient: PlaceAutocompleteCacheClient = FirestorePlaceAutocompleteCacheClient
+
+    /**
+     * Poi 의 도로명/구주소 중 차량에 실제로 보낼 주소를 결정한다.
+     * 부작용: 결정 결과를 destination_send_cache 에 upsert.
+     */
+    suspend fun resolve(poi: Poi): String {
+        val poiName = poi.poiName ?: return poi.getRoadAddress()
+        val roadAddress = poi.getRoadAddress()
+        val jibunAddress = poi.getAddress()
+
+        // 1. 로컬 캐시 hit → 그대로 사용
+        val dao = AppDatabase.getInstance().destinationSendCacheDao()
+        val cached = dao.find(poiName, poi.packageName)
+        if (cached != null && !cached.isExpire) {
+            return cached.sentAddress
+        }
+
+        // 2. nostore 또는 jibun 이 없거나 도로명과 동일 → 도로명 그대로
+        if (BuildConfig.BUILD_MODE != "playstore" || jibunAddress.isEmpty() || jibunAddress == roadAddress) {
+            saveLocal(poiName, poi.packageName, roadAddress, sentAsJibun = false)
+            return roadAddress
+        }
+
+        // 3. Remote Config 분기
+        val lookupEnabled = RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED)
+        if (!lookupEnabled) {
+            saveLocal(poiName, poi.packageName, roadAddress, sentAsJibun = false)
+            return roadAddress
+        }
+
+        // 4. Firestore cache 조회 (positive/negative 모두 분기)
+        when (cacheClient.lookup(roadAddress)) {
+            PlaceAutocompleteCacheEntry.Searchable -> {
+                saveLocal(poiName, poi.packageName, roadAddress, sentAsJibun = false)
+                return roadAddress
+            }
+
+            PlaceAutocompleteCacheEntry.NotSearchable -> {
+                saveLocal(poiName, poi.packageName, jibunAddress, sentAsJibun = true)
+                return jibunAddress
+            }
+
+            null -> {
+                // miss → 다음 단계로
+            }
+        }
+
+        // 5. update_enabled 면 Places SDK 호출 + matcher 판단 + Firestore 에 결과 기록
+        val updateEnabled = RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_ENABLED)
+        if (!updateEnabled) {
+            saveLocal(poiName, poi.packageName, roadAddress, sentAsJibun = false)
+            return roadAddress
+        }
+
+        val matched =
+            try {
+                matcher.isMatch(roadAddress)
+            } catch (e: CancellationException) {
+                // 코루틴 취소는 그대로 상위로 전파해 cancellation 신호 손실 방지.
+                throw e
+            } catch (e: Exception) {
+                AnalysisUtil.log("matcher failed: ${e.javaClass.simpleName}")
+                AnalysisUtil.recordException(e)
+                null
+            }
+
+        return if (matched == null) {
+            // SDK/매처 실패 → 어느 결과인지 모르므로 Firestore write 하지 않음, 도로명 fallback
+            saveLocal(poiName, poi.packageName, roadAddress, sentAsJibun = false)
+            roadAddress
+        } else if (matched) {
+            cacheClient.cache(roadAddress, searchable = true)
+            saveLocal(poiName, poi.packageName, roadAddress, sentAsJibun = false)
+            roadAddress
+        } else {
+            cacheClient.cache(roadAddress, searchable = false)
+            saveLocal(poiName, poi.packageName, jibunAddress, sentAsJibun = true)
+            jibunAddress
+        }
+    }
+
+    private suspend fun saveLocal(
+        poi: String,
+        packageName: String,
+        sentAddress: String,
+        sentAsJibun: Boolean,
+    ) {
+        val dao = AppDatabase.getInstance().destinationSendCacheDao()
+        dao.upsert(
+            DestinationSendCacheEntity(
+                poi = poi,
+                sentAddress = sentAddress,
+                sentAsJibun = sentAsJibun,
+                packageName = packageName,
+                created = Date(),
+            ),
+        )
+    }
+}

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
@@ -16,36 +16,30 @@ object DestinationAddressResolver {
     @Volatile
     var cacheClient: PlaceAutocompleteCacheClient = FirestorePlaceAutocompleteCacheClient
 
-    /**
-     * Poi 의 도로명/구주소 중 차량에 실제로 보낼 주소를 결정한다.
-     * 부작용: 결정 결과를 destination_send_cache 에 upsert.
-     */
     suspend fun resolve(poi: Poi): String {
         val poiName = poi.poiName ?: return poi.getRoadAddress()
         val roadAddress = poi.getRoadAddress()
         val jibunAddress = poi.getAddress()
 
-        // 1. 로컬 캐시 hit → 그대로 사용
         val dao = AppDatabase.getInstance().destinationSendCacheDao()
         val cached = dao.find(poiName, poi.packageName)
         if (cached != null && !cached.isExpire) {
             return cached.sentAddress
         }
 
-        // 2. nostore 또는 jibun 이 없거나 도로명과 동일 → 도로명 그대로
-        if (BuildConfig.BUILD_MODE != "playstore" || jibunAddress.isEmpty() || jibunAddress == roadAddress) {
+        // nostore release 는 Firebase 비활성. debug 빌드는 flavor 무관 통과해 검증 가능.
+        val firebaseDisabledFlavor = !BuildConfig.DEBUG && BuildConfig.BUILD_MODE != "playstore"
+        if (firebaseDisabledFlavor || jibunAddress.isEmpty() || jibunAddress == roadAddress) {
             saveLocal(poiName, poi.packageName, roadAddress, sentAsJibun = false)
             return roadAddress
         }
 
-        // 3. Remote Config 분기
         val lookupEnabled = RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED)
         if (!lookupEnabled) {
             saveLocal(poiName, poi.packageName, roadAddress, sentAsJibun = false)
             return roadAddress
         }
 
-        // 4. Firestore cache 조회 (positive/negative 모두 분기)
         when (cacheClient.lookup(roadAddress)) {
             PlaceAutocompleteCacheEntry.Searchable -> {
                 saveLocal(poiName, poi.packageName, roadAddress, sentAsJibun = false)
@@ -57,12 +51,9 @@ object DestinationAddressResolver {
                 return jibunAddress
             }
 
-            null -> {
-                // miss → 다음 단계로
-            }
+            null -> Unit
         }
 
-        // 5. update_enabled 면 Places SDK 호출 + matcher 판단 + Firestore 에 결과 기록
         val updateEnabled = RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_ENABLED)
         if (!updateEnabled) {
             saveLocal(poiName, poi.packageName, roadAddress, sentAsJibun = false)
@@ -73,16 +64,14 @@ object DestinationAddressResolver {
             try {
                 matcher.isMatch(roadAddress)
             } catch (e: CancellationException) {
-                // 코루틴 취소는 그대로 상위로 전파해 cancellation 신호 손실 방지.
                 throw e
             } catch (e: Exception) {
-                AnalysisUtil.log("matcher failed: ${e.javaClass.simpleName}")
                 AnalysisUtil.recordException(e)
                 null
             }
 
         return if (matched == null) {
-            // SDK/매처 실패 → 어느 결과인지 모르므로 Firestore write 하지 않음, 도로명 fallback
+            // 일시 오류로 잘못된 negative 가 영구 기록되지 않도록 cache write skip.
             saveLocal(poiName, poi.packageName, roadAddress, sentAsJibun = false)
             roadAddress
         } else if (matched) {

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
@@ -51,7 +51,9 @@ object DestinationAddressResolver {
                 return jibunAddress
             }
 
-            null -> Unit
+            null -> {
+                // miss → 다음 단계
+            }
         }
 
         val updateEnabled = RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_ENABLED)

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/FirebaseAppCheckTokenProvider.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/FirebaseAppCheckTokenProvider.kt
@@ -1,0 +1,18 @@
+package me.zipi.navitotesla.service.place
+
+import androidx.concurrent.futures.CallbackToFutureAdapter
+import com.google.android.libraries.places.api.auth.PlacesAppCheckTokenProvider
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.firebase.appcheck.FirebaseAppCheck
+
+class FirebaseAppCheckTokenProvider : PlacesAppCheckTokenProvider {
+    override fun fetchAppCheckToken(): ListenableFuture<String> =
+        CallbackToFutureAdapter.getFuture { completer ->
+            FirebaseAppCheck
+                .getInstance()
+                .getAppCheckToken(false)
+                .addOnSuccessListener { completer.set(it.token) }
+                .addOnFailureListener { completer.setException(it) }
+            "FirebaseAppCheck"
+        }
+}

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteCacheClient.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteCacheClient.kt
@@ -1,18 +1,14 @@
 package me.zipi.navitotesla.service.place
 
-import com.google.firebase.firestore.FieldValue
+import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.tasks.await
 import me.zipi.navitotesla.util.AnalysisUtil
+import me.zipi.navitotesla.util.RemoteConfigUtil
 import java.security.MessageDigest
+import java.util.Date
 
-/**
- * 캐시 조회 결과.
- *   - null = 캐시 miss (분석된 적 없거나 조회 실패)
- *   - Searchable = positive (자동완성 매치 있음 → 도로명 전송)
- *   - NotSearchable = negative (자동완성 매치 없음 → 구주소 전송)
- */
 sealed class PlaceAutocompleteCacheEntry {
     object Searchable : PlaceAutocompleteCacheEntry()
 
@@ -20,6 +16,7 @@ sealed class PlaceAutocompleteCacheEntry {
 }
 
 interface PlaceAutocompleteCacheClient {
+    /** null = miss (분석된 적 없거나 조회 실패). */
     suspend fun lookup(address: String): PlaceAutocompleteCacheEntry?
 
     suspend fun cache(
@@ -31,7 +28,8 @@ interface PlaceAutocompleteCacheClient {
 object FirestorePlaceAutocompleteCacheClient : PlaceAutocompleteCacheClient {
     private const val COLLECTION = "place_autocomplete_cache"
     private const val FIELD_SEARCHABLE = "searchable"
-    private const val FIELD_CREATED_AT = "createdAt"
+    private const val FIELD_EXPIRES_AT = "expiresAt"
+    private const val DEFAULT_TTL_DAYS = 30L
 
     override suspend fun lookup(address: String): PlaceAutocompleteCacheEntry? =
         try {
@@ -45,8 +43,7 @@ object FirestorePlaceAutocompleteCacheClient : PlaceAutocompleteCacheClient {
             if (!doc.exists()) {
                 null
             } else {
-                val searchable = doc.getBoolean(FIELD_SEARCHABLE)
-                when (searchable) {
+                when (doc.getBoolean(FIELD_SEARCHABLE)) {
                     true -> PlaceAutocompleteCacheEntry.Searchable
                     false -> PlaceAutocompleteCacheEntry.NotSearchable
                     null -> null
@@ -55,7 +52,6 @@ object FirestorePlaceAutocompleteCacheClient : PlaceAutocompleteCacheClient {
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            AnalysisUtil.log("FirestorePlaceAutocompleteCacheClient.lookup failed: ${e.javaClass.simpleName}")
             AnalysisUtil.recordException(e)
             null
         }
@@ -65,6 +61,8 @@ object FirestorePlaceAutocompleteCacheClient : PlaceAutocompleteCacheClient {
         searchable: Boolean,
     ) {
         try {
+            val ttlDays = RemoteConfigUtil.getLong(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_TTL_DAYS).takeIf { it > 0L } ?: DEFAULT_TTL_DAYS
+            val expiresAt = Timestamp(Date(System.currentTimeMillis() + ttlDays * 24L * 60L * 60L * 1000L))
             FirebaseFirestore
                 .getInstance()
                 .collection(COLLECTION)
@@ -72,13 +70,12 @@ object FirestorePlaceAutocompleteCacheClient : PlaceAutocompleteCacheClient {
                 .set(
                     mapOf(
                         FIELD_SEARCHABLE to searchable,
-                        FIELD_CREATED_AT to FieldValue.serverTimestamp(),
+                        FIELD_EXPIRES_AT to expiresAt,
                     ),
                 ).await()
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            AnalysisUtil.log("FirestorePlaceAutocompleteCacheClient.cache failed: ${e.javaClass.simpleName}")
             AnalysisUtil.recordException(e)
         }
     }

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteCacheClient.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteCacheClient.kt
@@ -1,6 +1,7 @@
 package me.zipi.navitotesla.service.place
 
 import com.google.firebase.Timestamp
+import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.tasks.await
@@ -29,6 +30,7 @@ object FirestorePlaceAutocompleteCacheClient : PlaceAutocompleteCacheClient {
     private const val COLLECTION = "place_autocomplete_cache"
     private const val FIELD_SEARCHABLE = "searchable"
     private const val FIELD_EXPIRES_AT = "expiresAt"
+    private const val FIELD_CREATED_AT = "createdAt"
     private const val DEFAULT_TTL_DAYS = 30L
 
     override suspend fun lookup(address: String): PlaceAutocompleteCacheEntry? =
@@ -71,6 +73,7 @@ object FirestorePlaceAutocompleteCacheClient : PlaceAutocompleteCacheClient {
                     mapOf(
                         FIELD_SEARCHABLE to searchable,
                         FIELD_EXPIRES_AT to expiresAt,
+                        FIELD_CREATED_AT to FieldValue.serverTimestamp(),
                     ),
                 ).await()
         } catch (e: CancellationException) {

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteCacheClient.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteCacheClient.kt
@@ -1,0 +1,91 @@
+package me.zipi.navitotesla.service.place
+
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.tasks.await
+import me.zipi.navitotesla.util.AnalysisUtil
+import java.security.MessageDigest
+
+/**
+ * 캐시 조회 결과.
+ *   - null = 캐시 miss (분석된 적 없거나 조회 실패)
+ *   - Searchable = positive (자동완성 매치 있음 → 도로명 전송)
+ *   - NotSearchable = negative (자동완성 매치 없음 → 구주소 전송)
+ */
+sealed class PlaceAutocompleteCacheEntry {
+    object Searchable : PlaceAutocompleteCacheEntry()
+
+    object NotSearchable : PlaceAutocompleteCacheEntry()
+}
+
+interface PlaceAutocompleteCacheClient {
+    suspend fun lookup(address: String): PlaceAutocompleteCacheEntry?
+
+    suspend fun cache(
+        address: String,
+        searchable: Boolean,
+    )
+}
+
+object FirestorePlaceAutocompleteCacheClient : PlaceAutocompleteCacheClient {
+    private const val COLLECTION = "place_autocomplete_cache"
+    private const val FIELD_SEARCHABLE = "searchable"
+    private const val FIELD_CREATED_AT = "createdAt"
+
+    override suspend fun lookup(address: String): PlaceAutocompleteCacheEntry? =
+        try {
+            val doc =
+                FirebaseFirestore
+                    .getInstance()
+                    .collection(COLLECTION)
+                    .document(hash(address))
+                    .get()
+                    .await()
+            if (!doc.exists()) {
+                null
+            } else {
+                val searchable = doc.getBoolean(FIELD_SEARCHABLE)
+                when (searchable) {
+                    true -> PlaceAutocompleteCacheEntry.Searchable
+                    false -> PlaceAutocompleteCacheEntry.NotSearchable
+                    null -> null
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            AnalysisUtil.log("FirestorePlaceAutocompleteCacheClient.lookup failed: ${e.javaClass.simpleName}")
+            AnalysisUtil.recordException(e)
+            null
+        }
+
+    override suspend fun cache(
+        address: String,
+        searchable: Boolean,
+    ) {
+        try {
+            FirebaseFirestore
+                .getInstance()
+                .collection(COLLECTION)
+                .document(hash(address))
+                .set(
+                    mapOf(
+                        FIELD_SEARCHABLE to searchable,
+                        FIELD_CREATED_AT to FieldValue.serverTimestamp(),
+                    ),
+                ).await()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            AnalysisUtil.log("FirestorePlaceAutocompleteCacheClient.cache failed: ${e.javaClass.simpleName}")
+            AnalysisUtil.recordException(e)
+        }
+    }
+
+    private fun hash(address: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val bytes = digest.digest(address.toByteArray(Charsets.UTF_8))
+        return bytes.joinToString("") { "%02x".format(it) }
+    }
+}

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteMatcher.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteMatcher.kt
@@ -1,0 +1,15 @@
+package me.zipi.navitotesla.service.place
+
+interface PlaceAutocompleteMatcher {
+    suspend fun isMatch(input: String): Boolean
+}
+
+class RealPlaceAutocompleteMatcher(
+    private val client: PlacesAutocompleteClient = PlacesAutocompleteClient,
+    private val roadNumberMatcher: RoadNumberMatcher = RoadNumberMatcher(),
+) : PlaceAutocompleteMatcher {
+    override suspend fun isMatch(input: String): Boolean {
+        val predictions = client.fetchPredictions(input)
+        return roadNumberMatcher.matches(input, predictions)
+    }
+}

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlacesAutocompleteClient.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlacesAutocompleteClient.kt
@@ -14,12 +14,6 @@ object PlacesAutocompleteClient {
         client = c
     }
 
-    /**
-     * Places autocomplete 호출. 결과가 빈 리스트면 "자동완성에 없는 주소" 의미 (정상 흐름).
-     * 호출 실패(client 미초기화 / 네트워크 / quota / SDK 예외) 는 예외를 그대로 전파해
-     * 호출자가 잘못된 영구 cache write 를 피하도록 한다 — 일시 오류가 NotSearchable 로
-     * 영구 기록되는 사고 방지.
-     */
     @Throws(Exception::class)
     suspend fun fetchPredictions(input: String): List<AutocompletePrediction> {
         val c = client ?: throw IllegalStateException("Places client not initialized")

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlacesAutocompleteClient.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlacesAutocompleteClient.kt
@@ -1,0 +1,37 @@
+package me.zipi.navitotesla.service.place
+
+import com.google.android.libraries.places.api.model.AutocompletePrediction
+import com.google.android.libraries.places.api.model.AutocompleteSessionToken
+import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRequest
+import com.google.android.libraries.places.api.net.PlacesClient
+import kotlinx.coroutines.tasks.await
+
+object PlacesAutocompleteClient {
+    @Volatile
+    private var client: PlacesClient? = null
+
+    fun setClient(c: PlacesClient) {
+        client = c
+    }
+
+    /**
+     * Places autocomplete 호출. 결과가 빈 리스트면 "자동완성에 없는 주소" 의미 (정상 흐름).
+     * 호출 실패(client 미초기화 / 네트워크 / quota / SDK 예외) 는 예외를 그대로 전파해
+     * 호출자가 잘못된 영구 cache write 를 피하도록 한다 — 일시 오류가 NotSearchable 로
+     * 영구 기록되는 사고 방지.
+     */
+    @Throws(Exception::class)
+    suspend fun fetchPredictions(input: String): List<AutocompletePrediction> {
+        val c = client ?: throw IllegalStateException("Places client not initialized")
+        val token = AutocompleteSessionToken.newInstance()
+        val request =
+            FindAutocompletePredictionsRequest
+                .builder()
+                .setSessionToken(token)
+                .setQuery(input)
+                .setCountries("KR")
+                .setRegionCode("KR")
+                .build()
+        return c.findAutocompletePredictions(request).await().autocompletePredictions
+    }
+}

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/RoadNumberMatcher.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/RoadNumberMatcher.kt
@@ -1,0 +1,48 @@
+package me.zipi.navitotesla.service.place
+
+import com.google.android.libraries.places.api.model.AutocompletePrediction
+
+/**
+ * 한국 도로명 주소 매처 (lenient).
+ *
+ * navi 응답은 보통 `시도 + 시군구 + 도로명 + 번지` 형식이지만 응답에 따라:
+ *   - 시도명 표기가 다르거나 (제주도 ↔ 제주특별자치도, 전북 ↔ 전북특별자치도)
+ *   - 시군구 추가 (입력 "용인시 구갈로 51" ↔ 응답 "용인시 기흥구 구갈로 51")
+ *   - 괄호 부가 토큰 (입력 "구갈로 51 (구갈동)" — PoiFinder 의 withLocalName 결과)
+ * 같은 변형이 발생.
+ *
+ * 알고리즘:
+ *   1. 입력/응답 모두 토큰화 + 괄호 토큰 제거 + 빈 토큰 제거
+ *   2. 입력 첫 토큰 (시도명 가정) 제거
+ *   3. 남은 입력 토큰이 응답 토큰 집합에 **모두 포함** 되면 매치 (순서 무관, 중간 토큰 끼어 있어도 OK)
+ *
+ * 사전 없이 토큰 비교만 하므로 행정구역 명칭 변경에도 robust. 너프 정책 — 도로명 주소가 가능한 한
+ * 차량으로 전송되도록 너그럽게 매치하지만, 번지가 응답에 없거나 다르면 no match (구주소 fallback).
+ */
+class RoadNumberMatcher {
+    fun matches(
+        input: String,
+        predictions: List<AutocompletePrediction>,
+    ): Boolean {
+        val tokens = tokenize(input).drop(1)
+        if (tokens.isEmpty()) return false
+        return predictions.any { p ->
+            val descTokens = tokenize(p.getFullText(null).toString()).toSet()
+            tokens.all { it in descTokens }
+        }
+    }
+
+    private fun tokenize(s: String): List<String> =
+        s
+            .trim()
+            .replace(PAREN_NOISE, " ")
+            .split(WHITESPACE)
+            .filter { it.isNotEmpty() }
+
+    companion object {
+        private val WHITESPACE = Regex("\\s+")
+
+        // PoiFinder.getRoadAddressName(withLocalName=true) 가 도로명 끝에 붙이는 "(동이름)" 형태 부가 토큰 제거.
+        private val PAREN_NOISE = Regex("""\([^)]*\)""")
+    }
+}

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/RoadNumberMatcher.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/RoadNumberMatcher.kt
@@ -3,21 +3,7 @@ package me.zipi.navitotesla.service.place
 import com.google.android.libraries.places.api.model.AutocompletePrediction
 
 /**
- * 한국 도로명 주소 매처 (lenient).
- *
- * navi 응답은 보통 `시도 + 시군구 + 도로명 + 번지` 형식이지만 응답에 따라:
- *   - 시도명 표기가 다르거나 (제주도 ↔ 제주특별자치도, 전북 ↔ 전북특별자치도)
- *   - 시군구 추가 (입력 "용인시 구갈로 51" ↔ 응답 "용인시 기흥구 구갈로 51")
- *   - 괄호 부가 토큰 (입력 "구갈로 51 (구갈동)" — PoiFinder 의 withLocalName 결과)
- * 같은 변형이 발생.
- *
- * 알고리즘:
- *   1. 입력/응답 모두 토큰화 + 괄호 토큰 제거 + 빈 토큰 제거
- *   2. 입력 첫 토큰 (시도명 가정) 제거
- *   3. 남은 입력 토큰이 응답 토큰 집합에 **모두 포함** 되면 매치 (순서 무관, 중간 토큰 끼어 있어도 OK)
- *
- * 사전 없이 토큰 비교만 하므로 행정구역 명칭 변경에도 robust. 너프 정책 — 도로명 주소가 가능한 한
- * 차량으로 전송되도록 너그럽게 매치하지만, 번지가 응답에 없거나 다르면 no match (구주소 fallback).
+ * 도로명 주소 매칭 룰. 가장 앞부분을 제외하고 포함여부로 한다. 서울시/경기도 등을 제외한다. (특별시, 특별자치시 등)
  */
 class RoadNumberMatcher {
     fun matches(
@@ -42,7 +28,7 @@ class RoadNumberMatcher {
     companion object {
         private val WHITESPACE = Regex("\\s+")
 
-        // PoiFinder.getRoadAddressName(withLocalName=true) 가 도로명 끝에 붙이는 "(동이름)" 형태 부가 토큰 제거.
+        // PoiFinder.getRoadAddressName(withLocalName=true) 의 "(동이름)" 부가 토큰 제거.
         private val PAREN_NOISE = Regex("""\([^)]*\)""")
     }
 }

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/AppUpdaterUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/AppUpdaterUtil.kt
@@ -77,6 +77,9 @@ object AppUpdaterUtil {
             if (activity == null) {
                 return@withContext
             }
+            if (BuildConfig.DEBUG) {
+                return@withContext
+            }
 
             if (!isForce && (abs(System.currentTimeMillis() - dialogLastCheck) < 5 * 60 * 1000 || isDoNotShow())) {
                 return@withContext
@@ -321,7 +324,7 @@ object AppUpdaterUtil {
 
     @Suppress("KotlinConstantConditions")
     suspend fun notification(context: Context) {
-        if (BuildConfig.BUILD_MODE == "playstore") {
+        if (BuildConfig.BUILD_MODE == "playstore" || BuildConfig.DEBUG) {
             return
         }
         if (abs(System.currentTimeMillis() - notificationLastCheck) < 5 * 60 * 1000 || isDoNotShow()) {

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/RemoteConfigUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/RemoteConfigUtil.kt
@@ -9,6 +9,7 @@ object RemoteConfigUtil {
     const val KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED = "googlePlaceCheckLookupEnabled"
     const val KEY_GOOGLE_PLACE_CHECK_UPDATE_ENABLED = "googlePlaceCheckUpdateEnabled"
     const val KEY_GOOGLE_PLACES_API_KEY = "googlePlacesApiKey"
+    const val KEY_GOOGLE_PLACE_CHECK_TTL_DAYS = "googlePlaceCheckTtlDays"
     private const val FETCH_INTERVAL_SECONDS = 20 * 3600L
     private const val DEFAULT_VALUE = "default"
 
@@ -42,5 +43,10 @@ object RemoteConfigUtil {
     fun getBoolean(key: String): Boolean {
         val remoteConfig = FirebaseRemoteConfig.getInstance()
         return remoteConfig.getBoolean(key)
+    }
+
+    fun getLong(key: String): Long {
+        val remoteConfig = FirebaseRemoteConfig.getInstance()
+        return remoteConfig.getLong(key)
     }
 }

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/RemoteConfigUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/RemoteConfigUtil.kt
@@ -6,6 +6,9 @@ import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
 import me.zipi.navitotesla.R
 
 object RemoteConfigUtil {
+    const val KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED = "googlePlaceCheckLookupEnabled"
+    const val KEY_GOOGLE_PLACE_CHECK_UPDATE_ENABLED = "googlePlaceCheckUpdateEnabled"
+    const val KEY_GOOGLE_PLACES_API_KEY = "googlePlacesApiKey"
     private const val FETCH_INTERVAL_SECONDS = 20 * 3600L
     private const val DEFAULT_VALUE = "default"
 

--- a/app/src/main/res/xml/remote_config_defaults.xml
+++ b/app/src/main/res/xml/remote_config_defaults.xml
@@ -20,4 +20,16 @@
         <key>naverApiRatio</key>
         <value>100</value>
     </entry>
+    <entry>
+        <key>googlePlaceCheckLookupEnabled</key>
+        <value>false</value>
+    </entry>
+    <entry>
+        <key>googlePlaceCheckUpdateEnabled</key>
+        <value>false</value>
+    </entry>
+    <entry>
+        <key>googlePlacesApiKey</key>
+        <value>default</value>
+    </entry>
 </defaultsMap><!-- END xml_defaults -->

--- a/app/src/main/res/xml/remote_config_defaults.xml
+++ b/app/src/main/res/xml/remote_config_defaults.xml
@@ -32,4 +32,8 @@
         <key>googlePlacesApiKey</key>
         <value>default</value>
     </entry>
+    <entry>
+        <key>googlePlaceCheckTtlDays</key>
+        <value>30</value>
+    </entry>
 </defaultsMap><!-- END xml_defaults -->

--- a/app/src/release/kotlin/me/zipi/navitotesla/util/AppCheckUtil.kt
+++ b/app/src/release/kotlin/me/zipi/navitotesla/util/AppCheckUtil.kt
@@ -1,0 +1,14 @@
+package me.zipi.navitotesla.util
+
+import com.google.firebase.appcheck.FirebaseAppCheck
+import com.google.firebase.appcheck.playintegrity.PlayIntegrityAppCheckProviderFactory
+import me.zipi.navitotesla.BuildConfig
+
+object AppCheckUtil {
+    fun initialize() {
+        if (BuildConfig.BUILD_MODE != "playstore") return
+        FirebaseAppCheck
+            .getInstance()
+            .installAppCheckProviderFactory(PlayIntegrityAppCheckProviderFactory.getInstance())
+    }
+}

--- a/app/src/test/kotlin/me/zipi/navitotesla/receiver/NotificationListenerTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/receiver/NotificationListenerTest.kt
@@ -77,11 +77,12 @@ class NotificationListenerTest {
 
     @Test
     fun `TMap (KU) 알림 수신 시 ShareWorker startShare 가 호출된다`() {
-        val sbn = buildSbn(
-            packageName = "com.skt.tmap.ku",
-            title = "경로주행",
-            text = "내 위치 > 강남역",
-        )
+        val sbn =
+            buildSbn(
+                packageName = "com.skt.tmap.ku",
+                title = "경로주행",
+                text = "내 위치 > 강남역",
+            )
 
         listener.onNotificationPosted(sbn)
 
@@ -97,11 +98,12 @@ class NotificationListenerTest {
 
     @Test
     fun `TMap (SK) 알림 수신 시 ShareWorker startShare 가 호출된다`() {
-        val sbn = buildSbn(
-            packageName = "com.skt.skaf.l001mtm091",
-            title = "경로주행",
-            text = "내 위치 > 송파구청",
-        )
+        val sbn =
+            buildSbn(
+                packageName = "com.skt.skaf.l001mtm091",
+                title = "경로주행",
+                text = "내 위치 > 송파구청",
+            )
 
         listener.onNotificationPosted(sbn)
 
@@ -117,11 +119,12 @@ class NotificationListenerTest {
 
     @Test
     fun `KakaoNavi 알림 수신 시 ShareWorker startShare 가 호출된다`() {
-        val sbn = buildSbn(
-            packageName = "com.locnall.KimGiSa",
-            title = "길안내 주행 중",
-            text = "목적지 : 송파구청",
-        )
+        val sbn =
+            buildSbn(
+                packageName = "com.locnall.KimGiSa",
+                title = "길안내 주행 중",
+                text = "목적지 : 송파구청",
+            )
 
         listener.onNotificationPosted(sbn)
 
@@ -137,11 +140,12 @@ class NotificationListenerTest {
 
     @Test
     fun `지원하지 않는 패키지의 알림은 ShareWorker 를 호출하지 않는다`() {
-        val sbn = buildSbn(
-            packageName = "com.google.android.apps.maps",
-            title = "Driving",
-            text = "Continue ahead",
-        )
+        val sbn =
+            buildSbn(
+                packageName = "com.google.android.apps.maps",
+                title = "Driving",
+                text = "Continue ahead",
+            )
 
         listener.onNotificationPosted(sbn)
 
@@ -155,23 +159,35 @@ class NotificationListenerTest {
         title: String,
         text: String,
     ): StatusBarNotification {
-        val notification = Notification().apply {
-            extras = Bundle().apply {
-                putString(Notification.EXTRA_TITLE, title)
-                putString(Notification.EXTRA_TEXT, text)
+        val notification =
+            Notification().apply {
+                extras =
+                    Bundle().apply {
+                        putString(Notification.EXTRA_TITLE, title)
+                        putString(Notification.EXTRA_TEXT, text)
+                    }
             }
-        }
         return StatusBarNotification(
-            /* pkg = */ packageName,
-            /* opPkg = */ packageName,
-            /* id = */ 1,
-            /* tag = */ "tag",
-            /* uid = */ 0,
-            /* initialPid = */ 0,
-            /* score = */ 0,
-            /* notification = */ notification,
-            /* user = */ UserHandle.getUserHandleForUid(0),
-            /* postTime = */ System.currentTimeMillis(),
+            // pkg =
+            packageName,
+            // opPkg =
+            packageName,
+            // id =
+            1,
+            // tag =
+            "tag",
+            // uid =
+            0,
+            // initialPid =
+            0,
+            // score =
+            0,
+            // notification =
+            notification,
+            // user =
+            UserHandle.getUserHandleForUid(0),
+            // postTime =
+            System.currentTimeMillis(),
         )
     }
 }

--- a/app/src/test/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolverTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolverTest.kt
@@ -1,0 +1,182 @@
+package me.zipi.navitotesla.service.place
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.runBlocking
+import me.zipi.navitotesla.BuildConfig
+import me.zipi.navitotesla.db.AppDatabase
+import me.zipi.navitotesla.db.DestinationSendCacheDao
+import me.zipi.navitotesla.db.DestinationSendCacheEntity
+import me.zipi.navitotesla.model.Poi
+import me.zipi.navitotesla.util.AnalysisUtil
+import me.zipi.navitotesla.util.RemoteConfigUtil
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.Date
+
+class DestinationAddressResolverTest {
+    private val poi =
+        Poi(
+            poiName = "테스트 POI",
+            roadAddress = "서울특별시 종로구 세종대로 175",
+            address = "서울특별시 종로구 세종로 1-57",
+            packageName = "com.example.navi",
+        )
+
+    private lateinit var dao: DestinationSendCacheDao
+    private lateinit var fakeMatcher: PlaceAutocompleteMatcher
+    private lateinit var fakeCacheClient: PlaceAutocompleteCacheClient
+
+    @Before
+    fun setUp() {
+        assumeTrue("playstore flavor 에서만 의미", BuildConfig.BUILD_MODE == "playstore")
+        dao = mockk(relaxed = true)
+        coEvery { dao.find(any(), any()) } returns null
+
+        mockkStatic(FirebaseCrashlytics::class)
+        every { FirebaseCrashlytics.getInstance() } returns mockk(relaxed = true)
+        mockkObject(AnalysisUtil)
+        every { AnalysisUtil.log(any()) } returns Unit
+
+        mockkObject(AppDatabase)
+        val db = mockk<AppDatabase>()
+        every { db.destinationSendCacheDao() } returns dao
+        every { AppDatabase.getInstance() } returns db
+
+        mockkObject(RemoteConfigUtil)
+
+        fakeMatcher = mockk()
+        fakeCacheClient = mockk(relaxed = true)
+        DestinationAddressResolver.matcher = fakeMatcher
+        DestinationAddressResolver.cacheClient = fakeCacheClient
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+        DestinationAddressResolver.matcher = RealPlaceAutocompleteMatcher()
+        DestinationAddressResolver.cacheClient = FirestorePlaceAutocompleteCacheClient
+    }
+
+    @Test
+    fun `lookup disabled 이면 도로명 반환하고 Firestore 조회 안함`() =
+        runBlocking {
+            every { RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED) } returns false
+            every { RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_ENABLED) } returns false
+
+            val result = DestinationAddressResolver.resolve(poi)
+
+            assertEquals(poi.getRoadAddress(), result)
+            coVerify(exactly = 0) { fakeCacheClient.lookup(any()) }
+        }
+
+    @Test
+    fun `Firestore Searchable hit 이면 도로명 반환하고 SDK 호출 안함`() =
+        runBlocking {
+            every { RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED) } returns true
+            every { RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_ENABLED) } returns true
+            coEvery { fakeCacheClient.lookup(any()) } returns PlaceAutocompleteCacheEntry.Searchable
+
+            val result = DestinationAddressResolver.resolve(poi)
+
+            assertEquals(poi.getRoadAddress(), result)
+            coVerify(exactly = 0) { fakeMatcher.isMatch(any()) }
+            coVerify(exactly = 0) { fakeCacheClient.cache(any(), any()) }
+        }
+
+    @Test
+    fun `Firestore NotSearchable hit 이면 구주소 반환하고 SDK 호출 안함`() =
+        runBlocking {
+            every { RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED) } returns true
+            every { RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_ENABLED) } returns false
+            coEvery { fakeCacheClient.lookup(any()) } returns PlaceAutocompleteCacheEntry.NotSearchable
+
+            val result = DestinationAddressResolver.resolve(poi)
+
+            assertEquals(poi.getAddress(), result)
+            coVerify(exactly = 0) { fakeMatcher.isMatch(any()) }
+        }
+
+    @Test
+    fun `로컬 캐시 hit 이면 그대로 반환하고 Firestore 호출 안함`() =
+        runBlocking {
+            coEvery { dao.find(poi.poiName!!, poi.packageName) } returns
+                DestinationSendCacheEntity(
+                    poi = poi.poiName!!,
+                    sentAddress = "캐시된 주소",
+                    sentAsJibun = true,
+                    packageName = poi.packageName,
+                    created = Date(),
+                )
+
+            val result = DestinationAddressResolver.resolve(poi)
+
+            assertEquals("캐시된 주소", result)
+            coVerify(exactly = 0) { fakeCacheClient.lookup(any()) }
+        }
+
+    @Test
+    fun `miss + update enabled + matcher true 면 도로명 반환 + Firestore Searchable write`() =
+        runBlocking {
+            every { RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED) } returns true
+            every { RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_ENABLED) } returns true
+            coEvery { fakeCacheClient.lookup(any()) } returns null
+            coEvery { fakeMatcher.isMatch(any()) } returns true
+
+            val result = DestinationAddressResolver.resolve(poi)
+
+            assertEquals(poi.getRoadAddress(), result)
+            coVerify(exactly = 1) { fakeCacheClient.cache(poi.getRoadAddress(), true) }
+        }
+
+    @Test
+    fun `miss + update enabled + matcher false 면 구주소 반환 + Firestore NotSearchable write`() =
+        runBlocking {
+            every { RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED) } returns true
+            every { RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_ENABLED) } returns true
+            coEvery { fakeCacheClient.lookup(any()) } returns null
+            coEvery { fakeMatcher.isMatch(any()) } returns false
+
+            val result = DestinationAddressResolver.resolve(poi)
+
+            assertEquals(poi.getAddress(), result)
+            coVerify(exactly = 1) { fakeCacheClient.cache(poi.getRoadAddress(), false) }
+        }
+
+    @Test
+    fun `miss + update enabled + matcher throw 면 도로명 fallback + Firestore write 안함`() =
+        runBlocking {
+            every { RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED) } returns true
+            every { RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_ENABLED) } returns true
+            coEvery { fakeCacheClient.lookup(any()) } returns null
+            coEvery { fakeMatcher.isMatch(any()) } throws RuntimeException("simulated SDK failure")
+
+            val result = DestinationAddressResolver.resolve(poi)
+
+            assertEquals(poi.getRoadAddress(), result)
+            coVerify(exactly = 0) { fakeCacheClient.cache(any(), any()) }
+        }
+
+    @Test
+    fun `miss + update disabled 면 도로명 반환 + SDK 호출 안함 + Firestore write 안함`() =
+        runBlocking {
+            every { RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED) } returns true
+            every { RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_ENABLED) } returns false
+            coEvery { fakeCacheClient.lookup(any()) } returns null
+
+            val result = DestinationAddressResolver.resolve(poi)
+
+            assertEquals(poi.getRoadAddress(), result)
+            coVerify(exactly = 0) { fakeMatcher.isMatch(any()) }
+            coVerify(exactly = 0) { fakeCacheClient.cache(any(), any()) }
+        }
+}

--- a/app/src/test/kotlin/me/zipi/navitotesla/service/place/RoadNumberMatcherTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/service/place/RoadNumberMatcherTest.kt
@@ -1,0 +1,291 @@
+package me.zipi.navitotesla.service.place
+
+import android.text.SpannableString
+import com.google.android.libraries.places.api.model.AutocompletePrediction
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RoadNumberMatcherTest {
+    private val matcher = RoadNumberMatcher()
+
+    private fun prediction(fullText: String): AutocompletePrediction {
+        val spannable = mockk<SpannableString>()
+        every { spannable.toString() } returns fullText
+        val p = mockk<AutocompletePrediction>()
+        every { p.getFullText(null) } returns spannable
+        return p
+    }
+
+    private fun assertMatch(
+        input: String,
+        description: String,
+    ) {
+        assertTrue(
+            "expected match: '$input' vs '$description'",
+            matcher.matches(input, listOf(prediction(description))),
+        )
+    }
+
+    private fun assertNoMatch(
+        input: String,
+        description: String,
+    ) {
+        assertFalse(
+            "expected no match: '$input' vs '$description'",
+            matcher.matches(input, listOf(prediction(description))),
+        )
+    }
+
+    // === 기본 케이스 ===
+
+    @Test
+    fun `description 에 번지가 없으면 no match`() {
+        assertNoMatch(
+            input = "경기도 용인시 기흥구 구갈로 55",
+            description = "대한민국 경기도 용인시 기흥구 구갈로",
+        )
+    }
+
+    @Test
+    fun `도로명+번지 정확히 일치하면 match`() {
+        assertMatch(
+            input = "경기도 용인시 기흥구 구갈로 12",
+            description = "대한민국 경기도 용인시 기흥구 구갈로 12",
+        )
+    }
+
+    @Test
+    fun `prediction 목록이 비어 있으면 no match`() {
+        assertFalse(matcher.matches("경기도 어디시 어디로 1", emptyList()))
+    }
+
+    @Test
+    fun `시도명 한 토큰만 있으면 no match`() {
+        assertNoMatch(
+            input = "경기도",
+            description = "대한민국 경기도 용인시 구갈로 12",
+        )
+    }
+
+    // === 사용자 제공 14개 케이스 ===
+
+    @Test
+    fun `case01 세종특별시 입력 vs 세종특별자치시 응답 match`() {
+        assertMatch(
+            input = "세종특별시 정안세종로 1527",
+            description = "대한민국 세종특별자치시 정안세종로 1527",
+        )
+    }
+
+    @Test
+    fun `case02 세종시 줄임형도 match`() {
+        assertMatch(
+            input = "세종시 정안세종로 1527",
+            description = "대한민국 세종특별자치시 정안세종로 1527",
+        )
+    }
+
+    @Test
+    fun `case03 시도명 없는 입력도 도로명+번지가 응답에 있으면 match`() {
+        assertMatch(
+            input = "정안세종로 1527",
+            description = "대한민국 세종특별자치시 정안세종로 1527",
+        )
+    }
+
+    @Test
+    fun `case04 POI 이름 포함 + 응답에서 번지 빠지면 no match (다른 번지 안내 위험)`() {
+        assertNoMatch(
+            input = "제주특별자치도 제주시 광양9길 10 제주시청",
+            description = "대한민국 제주특별자치도 제주시 특별자치도 광양9길 제주시청",
+        )
+    }
+
+    @Test
+    fun `case05 제주특별자치도 정식명 + 번지 동일 match`() {
+        assertMatch(
+            input = "제주특별자치도 제주시 광양9길 10",
+            description = "대한민국 제주특별자치도 제주시 광양9길 10",
+        )
+    }
+
+    @Test
+    fun `case06 제주도 줄임형도 match`() {
+        assertMatch(
+            input = "제주도 제주시 광양9길 10",
+            description = "대한민국 제주도 제주시 광양9길 10",
+        )
+    }
+
+    @Test
+    fun `case07 제주시 중복 입력도 도 제거 후 매칭`() {
+        assertMatch(
+            input = "제주시 제주시 광양9길 10",
+            description = "대한민국 제주특별자치도 제주시 광양9길 10",
+        )
+    }
+
+    @Test
+    fun `case08 시 단독 입력도 응답에 부분 포함되면 match`() {
+        assertMatch(
+            input = "제주시 광양9길 10",
+            description = "대한민국 제주특별자치도 제주시 광양9길 10",
+        )
+    }
+
+    @Test
+    fun `case09 전북특별자치도 정식명 + POI + 응답 번지 빠짐 = no match`() {
+        assertNoMatch(
+            input = "전북특별자치도 익산시 인북로32길 1 익산시청",
+            description = "대한민국 전북특별자치도 익산시 인북로32길 익산시청",
+        )
+    }
+
+    @Test
+    fun `case10 전북 줄임형 + POI + 번지 빠짐 = no match`() {
+        assertNoMatch(
+            input = "전북 익산시 인북로32길 1 익산시청",
+            description = "대한민국 전북특별자치도 익산시 인북로32길 익산시청",
+        )
+    }
+
+    // === 번지 다른 응답 = no match (token-subset 알고리즘 — 같은 도로 다른 번지는 다른 토큰) ===
+
+    @Test
+    fun `case11 입력 번지가 응답과 다르면 no match (다른 번지 안내 위험)`() {
+        // 토큰 "1" 이 응답 토큰 집합 {"18-12", ...} 에 없음 → no match.
+        // 차량에 도로명+다른번지가 전송되어 잘못된 위치로 안내될 위험을 회피.
+        assertNoMatch(
+            input = "전북 익산시 인북로32길 1",
+            description = "대한민국 전북 익산시 인북로32길 18-12",
+        )
+    }
+
+    @Test
+    fun `case12 전라북도 정식명 - 번지 다르면 no match`() {
+        assertNoMatch(
+            input = "전라북도 익산시 인북로32길 1",
+            description = "대한민국 전라북도 익산시 인북로32길 18-12",
+        )
+    }
+
+    @Test
+    fun `case13 시도명 생략 - 번지 다르면 no match`() {
+        assertNoMatch(
+            input = "익산시 인북로32길 1",
+            description = "대한민국 전북특별자치도 익산시 인북로32길 18-12",
+        )
+    }
+
+    @Test
+    fun `case14 도로명+번지 단독 - 번지 다르면 no match`() {
+        assertNoMatch(
+            input = "인북로32길 1",
+            description = "대한민국 전북특별자치도 익산시 인북로32길 18-12",
+        )
+    }
+
+    // === 시군구 추가/제거 (token subset 으로 OK) ===
+
+    @Test
+    fun `입력에 시군구 없고 응답에는 있어도 match (구갈로 51 케이스)`() {
+        // PoiFinder 가 도로명 끝에 (동이름) 부가 토큰 + 응답에 "기흥구" 추가 끼어 있는 실제 케이스.
+        assertMatch(
+            input = "경기도 용인시 구갈로 51 (구갈동)",
+            description = "대한민국 경기도 용인시 기흥구 구갈로 51",
+        )
+    }
+
+    @Test
+    fun `응답에 부가 시군구 토큰이 끼어 있어도 token subset 으로 match`() {
+        assertMatch(
+            input = "용인시 구갈로 51",
+            description = "대한민국 경기도 용인시 기흥구 구갈로 51",
+        )
+    }
+
+    // === 괄호 부가 토큰 정규화 (PoiFinder withLocalName 결과) ===
+
+    @Test
+    fun `괄호 동이름 부가 토큰은 정규화로 제거됨`() {
+        assertMatch(
+            input = "경기도 용인시 기흥구 구갈로 12 (구갈동)",
+            description = "대한민국 경기도 용인시 기흥구 구갈로 12",
+        )
+    }
+
+    @Test
+    fun `응답에 괄호 토큰이 있고 입력에는 없어도 정규화로 동일하게 처리`() {
+        assertMatch(
+            input = "경기도 용인시 기흥구 구갈로 12",
+            description = "대한민국 경기도 용인시 기흥구 구갈로 12 (구갈동)",
+        )
+    }
+
+    // === 도로명 종류별 (대로/로/길) ===
+
+    @Test
+    fun `대로 도로명 매치`() {
+        assertMatch(
+            input = "서울특별시 강남구 영동대로 513",
+            description = "대한민국 서울특별시 강남구 영동대로 513",
+        )
+    }
+
+    @Test
+    fun `숫자 포함 길 도로명 매치`() {
+        assertMatch(
+            input = "제주시 광양9길 10",
+            description = "대한민국 제주특별자치도 제주시 광양9길 10",
+        )
+    }
+
+    @Test
+    fun `로뒤 숫자 포함 도로명 매치`() {
+        assertMatch(
+            input = "익산시 인북로32길 18-12",
+            description = "대한민국 전북특별자치도 익산시 인북로32길 18-12",
+        )
+    }
+
+    // === 광역시 / 특별시 매치 ===
+
+    @Test
+    fun `광역시 정식명 매치`() {
+        assertMatch(
+            input = "부산광역시 해운대구 해운대로 264",
+            description = "대한민국 부산광역시 해운대구 해운대로 264",
+        )
+    }
+
+    @Test
+    fun `서울시 줄임형 매치`() {
+        assertMatch(
+            input = "서울시 강남구 테헤란로 152",
+            description = "대한민국 서울시 강남구 테헤란로 152",
+        )
+    }
+
+    // === 상세주소 / POI 가 양쪽에 있으면 match ===
+
+    @Test
+    fun `입력에 동 같은 상세주소가 있고 응답에도 같이 있으면 match`() {
+        assertMatch(
+            input = "경기도 용인시 구갈로 12 상가동",
+            description = "대한민국 경기도 용인시 구갈로 12 상가동",
+        )
+    }
+
+    // === 공백 정규화 ===
+
+    @Test
+    fun `공백이 여러 개여도 정규화 후 매치`() {
+        assertMatch(
+            input = "서울시 강남구  영동대로 513",
+            description = "대한민국  서울시   강남구 영동대로 513",
+        )
+    }
+}

--- a/app/src/test/kotlin/me/zipi/navitotesla/util/EnablerUtilIsSendingCheckTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/util/EnablerUtilIsSendingCheckTest.kt
@@ -64,59 +64,66 @@ class EnablerUtilIsSendingCheckTest {
     }
 
     @Test
-    fun `appEnabled=false 면 false`() = runTest {
-        coEvery { PreferencesUtil.getBoolean("appEnabled", true) } returns false
+    fun `appEnabled=false 면 false`() =
+        runTest {
+            coEvery { PreferencesUtil.getBoolean("appEnabled", true) } returns false
 
-        assertFalse(EnablerUtil.isSendingCheck())
-    }
-
-    @Test
-    fun `appEnabled=true, appCondition=false 면 true`() = runTest {
-        // 기본 setUp 그대로
-        assertTrue(EnablerUtil.isSendingCheck())
-    }
+            assertFalse(EnablerUtil.isSendingCheck())
+        }
 
     @Test
-    fun `appCondition=true 인데 wifi-bluetooth 조건이 모두 비어있으면 true`() = runTest {
-        coEvery { PreferencesUtil.getBoolean("appCondition", false) } returns true
-
-        assertTrue(EnablerUtil.isSendingCheck())
-    }
-
-    @Test
-    fun `블루투스 조건과 일치하는 디바이스가 연결돼 있으면 true`() = runTest {
-        coEvery { PreferencesUtil.getBoolean("appCondition", false) } returns true
-        coEvery { dao.findCondition("bluetooth") } returns listOf(condition("MyCar"))
-        EnablerUtil.addConnectedBluetooth("MyCar")
-
-        assertTrue(EnablerUtil.isSendingCheck())
-    }
+    fun `appEnabled=true, appCondition=false 면 true`() =
+        runTest {
+            // 기본 setUp 그대로
+            assertTrue(EnablerUtil.isSendingCheck())
+        }
 
     @Test
-    fun `블루투스 조건은 있지만 연결된 디바이스가 다른 이름이면 false`() = runTest {
-        coEvery { PreferencesUtil.getBoolean("appCondition", false) } returns true
-        coEvery { dao.findCondition("bluetooth") } returns listOf(condition("MyCar"))
-        EnablerUtil.addConnectedBluetooth("OtherCar")
+    fun `appCondition=true 인데 wifi-bluetooth 조건이 모두 비어있으면 true`() =
+        runTest {
+            coEvery { PreferencesUtil.getBoolean("appCondition", false) } returns true
 
-        assertFalse(EnablerUtil.isSendingCheck())
-    }
-
-    @Test
-    fun `블루투스 조건은 있지만 연결된 디바이스가 없으면 false`() = runTest {
-        coEvery { PreferencesUtil.getBoolean("appCondition", false) } returns true
-        coEvery { dao.findCondition("bluetooth") } returns listOf(condition("MyCar"))
-
-        assertFalse(EnablerUtil.isSendingCheck())
-    }
+            assertTrue(EnablerUtil.isSendingCheck())
+        }
 
     @Test
-    fun `블루투스 매칭은 대소문자를 무시한다`() = runTest {
-        coEvery { PreferencesUtil.getBoolean("appCondition", false) } returns true
-        coEvery { dao.findCondition("bluetooth") } returns listOf(condition("MyCar"))
-        EnablerUtil.addConnectedBluetooth("MYCAR")
+    fun `블루투스 조건과 일치하는 디바이스가 연결돼 있으면 true`() =
+        runTest {
+            coEvery { PreferencesUtil.getBoolean("appCondition", false) } returns true
+            coEvery { dao.findCondition("bluetooth") } returns listOf(condition("MyCar"))
+            EnablerUtil.addConnectedBluetooth("MyCar")
 
-        assertTrue(EnablerUtil.isSendingCheck())
-    }
+            assertTrue(EnablerUtil.isSendingCheck())
+        }
+
+    @Test
+    fun `블루투스 조건은 있지만 연결된 디바이스가 다른 이름이면 false`() =
+        runTest {
+            coEvery { PreferencesUtil.getBoolean("appCondition", false) } returns true
+            coEvery { dao.findCondition("bluetooth") } returns listOf(condition("MyCar"))
+            EnablerUtil.addConnectedBluetooth("OtherCar")
+
+            assertFalse(EnablerUtil.isSendingCheck())
+        }
+
+    @Test
+    fun `블루투스 조건은 있지만 연결된 디바이스가 없으면 false`() =
+        runTest {
+            coEvery { PreferencesUtil.getBoolean("appCondition", false) } returns true
+            coEvery { dao.findCondition("bluetooth") } returns listOf(condition("MyCar"))
+
+            assertFalse(EnablerUtil.isSendingCheck())
+        }
+
+    @Test
+    fun `블루투스 매칭은 대소문자를 무시한다`() =
+        runTest {
+            coEvery { PreferencesUtil.getBoolean("appCondition", false) } returns true
+            coEvery { dao.findCondition("bluetooth") } returns listOf(condition("MyCar"))
+            EnablerUtil.addConnectedBluetooth("MYCAR")
+
+            assertTrue(EnablerUtil.isSendingCheck())
+        }
 
     private fun condition(name: String) = ConditionEntity(name = name, type = "bluetooth", created = Date())
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -10,10 +10,11 @@ service cloud.firestore {
       allow read: if true;
 
       allow create, update: if
-        request.resource.data.keys().hasOnly(['searchable', 'expiresAt'])
+        request.resource.data.keys().hasOnly(['searchable', 'expiresAt', 'createdAt'])
         && request.resource.data.searchable is bool
         && request.resource.data.expiresAt is timestamp
-        && request.resource.data.expiresAt > request.time;
+        && request.resource.data.expiresAt > request.time
+        && request.resource.data.createdAt == request.time;
 
       allow delete: if false;
     }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,27 @@
+// 배포: Firebase CLI 설치 후 `firebase deploy --only firestore:rules`
+// TTL Policy: Firestore 콘솔 > Time-to-live > 컬렉션 place_autocomplete_cache, 필드 createdAt, 만료 +30 days
+// App Check 활성화: Firebase 콘솔 > App Check > Firestore 강제 적용
+
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /place_autocomplete_cache/{docId} {
+      // 읽기: App Check 통과한 클라이언트만
+      allow read: if request.app != null;
+
+      // 쓰기: App Check + 정확한 스키마 (searchable: bool, createdAt: serverTimestamp)
+      allow create: if request.app != null
+        && request.resource.data.keys().hasOnly(['searchable', 'createdAt'])
+        && request.resource.data.searchable is bool
+        && request.resource.data.createdAt == request.time;
+
+      // 동일 분석 결과 재기록 허용 (스키마 동일 + searchable 값 동일성은 강제하지 않음 — 차후 알고리즘 변경 대비)
+      allow update: if request.app != null
+        && request.resource.data.keys().hasOnly(['searchable', 'createdAt'])
+        && request.resource.data.searchable is bool
+        && request.resource.data.createdAt == request.time;
+
+      allow delete: if false;
+    }
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,25 +1,19 @@
-// 배포: Firebase CLI 설치 후 `firebase deploy --only firestore:rules`
-// TTL Policy: Firestore 콘솔 > Time-to-live > 컬렉션 place_autocomplete_cache, 필드 createdAt, 만료 +30 days
-// App Check 활성화: Firebase 콘솔 > App Check > Firestore 강제 적용
+// 배포: `firebase deploy --only firestore:rules`
+// 콘솔 운영:
+//   - App Check > APIs > Cloud Firestore enforce 활성 (토큰 검증 위임)
+//   - Time-to-live > 컬렉션 place_autocomplete_cache, 필드 expiresAt (Timestamp). 만료 시각 도래 시 자동 삭제.
 
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /place_autocomplete_cache/{docId} {
-      // 읽기: App Check 통과한 클라이언트만
-      allow read: if request.app != null;
+      allow read: if true;
 
-      // 쓰기: App Check + 정확한 스키마 (searchable: bool, createdAt: serverTimestamp)
-      allow create: if request.app != null
-        && request.resource.data.keys().hasOnly(['searchable', 'createdAt'])
+      allow create, update: if
+        request.resource.data.keys().hasOnly(['searchable', 'expiresAt'])
         && request.resource.data.searchable is bool
-        && request.resource.data.createdAt == request.time;
-
-      // 동일 분석 결과 재기록 허용 (스키마 동일 + searchable 값 동일성은 강제하지 않음 — 차후 알고리즘 변경 대비)
-      allow update: if request.app != null
-        && request.resource.data.keys().hasOnly(['searchable', 'createdAt'])
-        && request.resource.data.searchable is bool
-        && request.resource.data.createdAt == request.time;
+        && request.resource.data.expiresAt is timestamp
+        && request.resource.data.expiresAt > request.time;
 
       allow delete: if false;
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ ktlint = "org.jlleitschuh.gradle.ktlint:14.2.0"
 
 [libraries]
 kotlin-coroutine = "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.11.0"
+kotlinx-coroutines-play-services = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.11.0"
 androidAppUpdateLibrary = "com.github.Piashsarker:AndroidAppUpdateLibrary:1.0.4"
 androidx-appcompat = "androidx.appcompat:appcompat:1.7.1"
 
@@ -49,6 +50,9 @@ firebase-config = { module = "com.google.firebase:firebase-config" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 firebase-perf = { module = "com.google.firebase:firebase-perf" }
+firebase-firestore = { module = "com.google.firebase:firebase-firestore" }
+firebase-appcheck-playintegrity = { module = "com.google.firebase:firebase-appcheck-playintegrity" }
+firebase-appcheck-debug = { module = "com.google.firebase:firebase-appcheck-debug" }
 
 junit = "junit:junit:4.13.2"
 androidx-test-junit = "androidx.test.ext:junit:1.3.0"
@@ -65,11 +69,12 @@ okhttp3 = "com.squareup.okhttp3:okhttp:5.3.2"
 okhttp3-logging = "com.squareup.okhttp3:logging-interceptor:5.3.2"
 
 ted-permission = "io.github.ParkSangGwon:tedpermission-coroutine:3.4.2"
+google-places = "com.google.android.libraries.places:places:4.4.1"
 
 [bundles]
 room = ["room-runtime", "room-ktx", "androidx-sqlite"]
 androidx-navigation = ["androidx-navigation-fragment", "androidx-navigation-ui"]
 androidx-lifecycle = ["androidx-lifecycle-livedata", "androidx-lifecycle-viewmodel", "androidx-lifecycle-common"]
 retrofit = ["retrofit", "retrofit-converter", "okhttp3", "okhttp3-logging"]
-firebase = ["firebase-config", "firebase-analytics", "firebase-crashlytics", "firebase-perf"]
+firebase = ["firebase-config", "firebase-analytics", "firebase-crashlytics", "firebase-perf", "firebase-firestore", "firebase-appcheck-playintegrity"]
 #androidx-compose = [ "androidx-compose-foundation", "androidx-compose-ui", "androidx-compose-material", "androidx-compose-uiTooling" ]


### PR DESCRIPTION
Closes #370

내비에서 받은 도로명 주소가 Google Places 자동완성에 없는 경우, 차량이 주변 후보를 보여줘 선택이 어려운 문제. 매번 Places API 를 호출하지 않도록 Firestore 공유 캐시 도입.

## 흐름
1. 로컬 캐시 (Room): 같은 POI 재안내 시 즉시 동일 결과
2. Firestore 캐시: 분석된 적 있으면 즉시 결과 (도로명 또는 구주소)
3. Places SDK 호출: 분석 안 된 주소만, Firestore 에 결과 저장

Remote Config 두 boolean 키 (기본 false):
- `googlePlaceCheckLookupEnabled`: Firestore 조회 단계 활성
- `googlePlaceCheckUpdateEnabled`: Places SDK 호출 + Firestore 쓰기 활성

기본값 false 라 머지 직후 동작 변화 없음. 운영자가 본인 디바이스만 update 활성화해 캐시 채우면, 다른 사용자는 lookup 만 활성으로 SDK 호출 없이 결과 사용.

## 머지 전 콘솔 작업
- App Check enforce: Cloud Firestore + Places API
- ``firebase deploy --only firestore:rules``
- Firestore TTL Policy: ``place_autocomplete_cache.expiresAt`` 필드
- Places API 키 발급 + Android 앱 패키지/SHA1 제한
- Remote Config 값 설정 (운영자 디바이스 한정 활성)

## 테스트
- 단위테스트: Resolver 8 케이스, Matcher (시도명 변형 / 번지 불일치 / 괄호 동이름 / 시군구 추가 등)
- 실디바이스: TMap 알림 시뮬레이션 (ADB) 으로 cache write/hit, Places SDK fallback, App Check 토큰 검증 확인