### PR TITLE
chore(ktlint): version 을 libs.versions.toml 로 관리

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -143,7 +143,7 @@ dependencies {
     androidTestImplementation(libs.room.testing)
 }
 ktlint {
-    version.set("1.7.1")
+    version.set(libs.versions.ktlint.cli.get())
     android.set(true)
     outputColorName.set("RED")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 kotlin = "2.3.21"
+ktlint-cli = "1.7.1"
 room = "2.8.4"
 androidx-navigation = "2.9.8"
 androidx-lifecycle = "2.10.0"
@@ -75,6 +76,7 @@ okhttp3-logging = "com.squareup.okhttp3:logging-interceptor:5.3.2"
 
 ted-permission = "io.github.ParkSangGwon:tedpermission-coroutine:3.4.2"
 google-places = "com.google.android.libraries.places:places:4.4.1"
+ktlint-cli = { module = "com.pinterest.ktlint:ktlint-cli", version.ref = "ktlint-cli" }
 
 [bundles]
 room = ["room-runtime", "room-ktx", "androidx-sqlite"]


### PR DESCRIPTION
하드코딩되어 있던 ktlint cli 버전(`1.7.1`)을 `libs.versions.toml` 의 `ktlint-cli` entry 로 이동.

`com.pinterest.ktlint:ktlint-cli` 를 library 로 등록해두면 Renovate 가 일반 maven dep 처럼 추적해서 자동으로 업데이트 PR 을 띄움. 실제 dependency 로는 추가하지 않고, plugin DSL 의 `version.set(libs.versions.ktlint.cli.get())` 에서만 참조.