### PR TITLE
build: minSdk 24 상향

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.ksp)
@@ -65,10 +63,6 @@ android {
 //            ext.enableCrashlytics = false
         }
     }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
     buildFeatures {
         viewBinding = true
         buildConfig = true
@@ -86,12 +80,6 @@ android {
 androidComponents {
     onVariants { variant ->
         variant.androidTest?.sources?.assets?.addStaticSourceDirectory("$projectDir/schemas")
-    }
-}
-
-kotlin {
-    compilerOptions {
-        jvmTarget = JvmTarget.JVM_11
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,7 +17,7 @@ android {
     defaultConfig {
         buildConfigField("String", "BUILD_MODE", "\"playstore\"")
         applicationId = "me.zipi.navitotesla"
-        minSdk = 23
+        minSdk = 24
         targetSdk = 36
 
         versionCode = Integer.parseInt(System.getenv("GITHUB_RUN_NUMBER") ?: "1")
@@ -66,8 +66,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
     buildFeatures {
         viewBinding = true
@@ -91,7 +91,7 @@ androidComponents {
 
 kotlin {
     compilerOptions {
-        jvmTarget = JvmTarget.JVM_1_8
+        jvmTarget = JvmTarget.JVM_11
     }
 }
 


### PR DESCRIPTION
## 변경
- `minSdk` 23 → 24 (Places SDK v5 가 24 요구. #372 unblock 용)
- `compileOptions` (sourceCompatibility/targetCompatibility) 와 `kotlin { compilerOptions { jvmTarget } }` 명시 제거 → AGP 디폴트 사용. [android/architecture-templates](https://github.com/android/architecture-templates/blob/base/app/build.gradle.kts) 컨벤션 따라감.

## 영향
- 안드로이드 6.0 (API 23) 단말 drop. 24(N) 이상부터 설치 가능.
- 코드상 `SDK_INT < 24` 분기 없음 (전부 O=26 이상). 추가 정리 대상 없음.

## 검증 (로컬)
- `./gradlew clean :app:assemblePlaystoreDebug :app:testPlaystoreDebugUnitTest` ✅
- `./gradlew :app:connectedPlaystoreDebugAndroidTest` (SM-T225N, Android 14): `PoiAddressMigrationTest` 3건 (Room migration 7→8 / 8→9 / 7→9 chained) 통과. `ExampleInstrumentedTest.useAppContext` 1건 실패는 사전 broken (debug applicationIdSuffix `.debug` 미고려 assertion, 이번 변경과 무관).