### PR TITLE
refactor(AnalysisUtil): 배치 writer + 롤링 로그 + 시작 로깅 정리

### DIFF
--- a/app/src/androidTest/java/me/zipi/navitotesla/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/me/zipi/navitotesla/ExampleInstrumentedTest.java
@@ -1,14 +1,14 @@
 package me.zipi.navitotesla;
 
-import android.content.Context;
+import static org.junit.Assert.assertEquals;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import android.content.Context;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 /**
  * Instrumented test, which will execute on an Android device.
@@ -19,8 +19,7 @@ import static org.junit.Assert.assertEquals;
 public class ExampleInstrumentedTest {
     @Test
     public void useAppContext() {
-        // Context of the app under test.
         Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
-        assertEquals("me.zipi.navitotesla", appContext.getPackageName());
+        assertEquals(BuildConfig.APPLICATION_ID, appContext.getPackageName());
     }
 }

--- a/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
@@ -47,7 +47,7 @@ class AppRepository private constructor(
                         },
                     ).addInterceptor(
                         HttpLoggingInterceptor {
-                            AnalysisUtil.appendLog("DEBUG", it)
+                            AnalysisUtil.debug(it)
                         }.apply {
                             level = HttpLoggingInterceptor.Level.BASIC
                         },
@@ -78,7 +78,7 @@ class AppRepository private constructor(
                         },
                     ).addInterceptor(
                         HttpLoggingInterceptor {
-                            AnalysisUtil.appendLog("DEBUG", it)
+                            AnalysisUtil.debug(it)
                         }.apply {
                             level = HttpLoggingInterceptor.Level.BASIC
                         },

--- a/app/src/main/kotlin/me/zipi/navitotesla/Application.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/Application.kt
@@ -23,19 +23,22 @@ class Application : Application() {
         PreferencesUtil.initialize(this.applicationContext)
         AppDatabase.initialize(this.applicationContext)
         AppRepository.initialize(database)
-        RemoteConfigUtil.initialize()
-        AppCheckUtil.initialize()
-        if (BuildConfig.DEBUG || BuildConfig.BUILD_MODE == "playstore") {
-            CoroutineScope(Dispatchers.IO).launch { initializePlacesSdk() }
-        }
         AnalysisUtil.initialize(this.applicationContext)
         AnalysisUtil.log(
             "App started: v${BuildConfig.VERSION_NAME} (${BuildConfig.BUILD_MODE}, " +
                 "sdk=${Build.VERSION.SDK_INT}, device=${Build.MANUFACTURER} ${Build.MODEL})",
         )
         FirebaseCrashlytics.getInstance().isCrashlyticsCollectionEnabled = !BuildConfig.DEBUG
-        if (!BuildConfig.DEBUG) {
-            CoroutineScope(Dispatchers.IO).launch { TokenWorker.startBackgroundWork(this@Application) }
+
+        CoroutineScope(Dispatchers.IO).launch {
+            RemoteConfigUtil.initialize()
+            AppCheckUtil.initialize()
+            if (BuildConfig.DEBUG || BuildConfig.BUILD_MODE == "playstore") {
+                initializePlacesSdk()
+            }
+            if (!BuildConfig.DEBUG) {
+                TokenWorker.startBackgroundWork(this@Application)
+            }
         }
     }
 

--- a/app/src/main/kotlin/me/zipi/navitotesla/model/ShareRequest.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/model/ShareRequest.kt
@@ -17,7 +17,7 @@ data class ShareRequest(
         val text: String,
     )
 }
-/**
+/*
  * POST https://owner-api.teslamotors.com/api/1/vehicles/1493132499069707/command/share
  *
  * {

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/AnalysisUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/AnalysisUtil.kt
@@ -8,7 +8,13 @@ import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import java.io.BufferedWriter
 import java.io.File
 import java.io.FileNotFoundException
@@ -17,14 +23,37 @@ import java.io.IOException
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.text.SimpleDateFormat
-import java.util.Calendar
+import java.util.Date
 import java.util.Locale
 import kotlin.coroutines.cancellation.CancellationException
 
 object AnalysisUtil {
+    private const val LOG_TAG = "NaviToTesla"
+    private const val LOG_FILE_NAME = "NaviToTesla.log"
+    private const val MAX_LOG_FILE_BYTES: Long = 100L * 1024L
+    private const val ROLL_TRIM_BYTES: Long = 10L * 1024L
+    private const val BATCH_MAX = 64
+    private const val BATCH_LINGER_MS = 200L
+    private const val CHANNEL_CAPACITY = 512
+
     private val firebaseCrashlytics = FirebaseCrashlytics.getInstance()
     private var firebaseAnalytics: FirebaseAnalytics? = null
     private var externalDir: String? = null
+
+    private val timestampFormatter =
+        object : ThreadLocal<SimpleDateFormat>() {
+            override fun initialValue(): SimpleDateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.getDefault())
+        }
+
+    private val logChannel =
+        Channel<String>(
+            capacity = CHANNEL_CAPACITY,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+    private val writerScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    @Volatile
+    private var writerJob: Job? = null
 
     fun initialize(context: Context) {
         firebaseAnalytics = FirebaseAnalytics.getInstance(context)
@@ -34,6 +63,13 @@ object AnalysisUtil {
             } else {
                 null
             }
+        startWriterIfNeeded()
+    }
+
+    @Synchronized
+    private fun startWriterIfNeeded() {
+        if (writerJob?.isActive == true) return
+        writerJob = writerScope.launch { writerLoop() }
     }
 
     fun logEvent(
@@ -43,27 +79,21 @@ object AnalysisUtil {
         firebaseAnalytics?.logEvent(event, param)
     }
 
-    fun log(message: String) {
-        appendLog("INFO", message)
-    }
+    fun log(message: String) = enqueue("INFO", message)
 
-    fun info(message: String) {
-        appendLog("INFO", message)
-    }
+    fun debug(message: String) = enqueue("DEBUG", message)
+
+    fun info(message: String) = enqueue("INFO", message)
 
     fun warn(
         message: String,
         e: Throwable? = null,
-    ) {
-        appendLog("WARN", withStack(message, e))
-    }
+    ) = enqueue("WARN", withStack(message, e))
 
     fun error(
         message: String,
         e: Throwable? = null,
-    ) {
-        appendLog("ERROR", withStack(message, e))
-    }
+    ) = enqueue("ERROR", withStack(message, e))
 
     private fun withStack(
         message: String,
@@ -84,7 +114,7 @@ object AnalysisUtil {
         }
         PrintWriter(StringWriter()).use { writer ->
             e.printStackTrace(writer)
-            appendLog("WARN", e.toString() + System.lineSeparator() + writer)
+            enqueue("WARN", e.toString() + System.lineSeparator() + writer)
         }
     }
 
@@ -100,55 +130,18 @@ object AnalysisUtil {
     }
 
     val logFilePath: String
-        get() = File("$externalDir/NaviToTesla.log").toString()
-
-    fun appendLog(
-        logLevel: String,
-        message: String,
-    ) {
-        CoroutineScope(Dispatchers.IO).launch {
-            Log.i(AnalysisUtil::class.java.name, message)
-            val dateTime =
-                SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).format(
-                    Calendar.getInstance().time,
-                )
-            val text = String.format("%s %s %s", dateTime, logLevel, message)
-            if (externalDir != null && !File(externalDir!!).exists() && !File(externalDir!!).mkdirs()) {
-                firebaseCrashlytics.log("create document directory fail")
-                return@launch
-            }
-            if (!isWritableLog) {
-                return@launch
-            }
-            val file = File("$externalDir/NaviToTesla.log")
-            if (file.exists() && file.length() > 50 * 1024) {
-                file.delete()
-            }
-            try {
-                BufferedWriter(FileWriter(file, true)).use { buf ->
-                    buf.append(text)
-                    buf.newLine()
-                }
-            } catch (_: FileNotFoundException) {
-            } catch (e: IOException) {
-                firebaseCrashlytics.recordException(e)
-            }
-        }
-    }
+        get() = File("$externalDir/$LOG_FILE_NAME").toString()
 
     val logFileSize: Long
         get() {
-            val file = File("$externalDir/NaviToTesla.log")
-            return if (!file.exists()) {
-                0L
-            } else {
-                file.length()
-            }
+            val file = File("$externalDir/$LOG_FILE_NAME")
+            return if (!file.exists()) 0L else file.length()
         }
 
     fun deleteLogFile() =
-        CoroutineScope(Dispatchers.IO).launch {
-            val file = File("$externalDir/NaviToTesla.log")
+        writerScope.launch {
+            val dir = externalDir ?: return@launch
+            val file = File("$dir/$LOG_FILE_NAME")
             if (file.exists()) {
                 file.delete()
             }
@@ -159,7 +152,7 @@ object AnalysisUtil {
         text: String,
     ) {
         try {
-            Log.i(AnalysisUtil::class.java.name, text)
+            Log.i(LOG_TAG, text)
             log(text)
             CoroutineScope(Dispatchers.Main).launch {
                 if (context != null) {
@@ -169,6 +162,104 @@ object AnalysisUtil {
         } catch (e: Exception) {
             recordException(e)
             e.printStackTrace()
+        }
+    }
+
+    private fun enqueue(
+        level: String,
+        message: String,
+    ) {
+        Log.i(LOG_TAG, message)
+        val line = formatLine(level, message)
+        logChannel.trySend(line)
+    }
+
+    private fun formatLine(
+        level: String,
+        message: String,
+    ): String {
+        val ts = timestampFormatter.get()!!.format(Date())
+        val thread = Thread.currentThread().name
+        return buildString(message.length + 64) {
+            append(ts)
+            append(' ')
+            append(level.padEnd(5))
+            append(" [")
+            append(thread)
+            append("] ")
+            append(message)
+        }
+    }
+
+    private suspend fun writerLoop() {
+        val pending = ArrayList<String>(BATCH_MAX)
+        while (writerScope.isActive) {
+            pending.clear()
+            val first = logChannel.receiveCatching().getOrNull() ?: return
+            pending.add(first)
+
+            val deadline = System.currentTimeMillis() + BATCH_LINGER_MS
+            while (pending.size < BATCH_MAX) {
+                val remaining = deadline - System.currentTimeMillis()
+                if (remaining <= 0L) break
+                val next =
+                    withTimeoutOrNull(remaining) {
+                        logChannel.receiveCatching().getOrNull()
+                    } ?: break
+                pending.add(next)
+            }
+
+            flush(pending)
+        }
+    }
+
+    private fun flush(lines: List<String>) {
+        val dir = externalDir ?: return
+        val parent = File(dir)
+        if (!parent.exists() && !parent.mkdirs()) {
+            firebaseCrashlytics.log("create document directory fail")
+            return
+        }
+        val file = File(parent, LOG_FILE_NAME)
+        try {
+            BufferedWriter(FileWriter(file, true)).use { buf ->
+                for (line in lines) {
+                    buf.append(line)
+                    buf.newLine()
+                }
+            }
+            rollIfNeeded(file)
+        } catch (_: FileNotFoundException) {
+        } catch (e: IOException) {
+            firebaseCrashlytics.recordException(e)
+        }
+    }
+
+    private fun rollIfNeeded(file: File) {
+        try {
+            val size = file.length()
+            if (size <= MAX_LOG_FILE_BYTES) return
+            val keepBytes = MAX_LOG_FILE_BYTES - ROLL_TRIM_BYTES
+            val rawSkip = (size - keepBytes).toInt().coerceAtLeast(0)
+            val bytes = file.readBytes()
+            val lf = '\n'.code.toByte()
+            var aligned = rawSkip
+            while (aligned < bytes.size && bytes[aligned] != lf) {
+                aligned++
+            }
+            if (aligned < bytes.size) aligned++
+            if (aligned >= bytes.size) {
+                file.writeBytes(ByteArray(0))
+            } else {
+                file.writeBytes(bytes.copyOfRange(aligned, bytes.size))
+            }
+        } catch (e: IOException) {
+            firebaseCrashlytics.recordException(e)
+        } catch (_: OutOfMemoryError) {
+            try {
+                file.writeBytes(ByteArray(0))
+            } catch (_: IOException) {
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

`AnalysisUtil.appendLog` 가 호출마다 코루틴 + BufferedWriter open/close 를 반복하던 구조를 단일 writer 코루틴 + Channel 기반 배치 쓰기로 변경. 50KB 초과 시 파일 통째 삭제하던 회전 정책을 100KB 초과 시 앞 ~10KB 라인 단위 트림으로 교체. 호출 API 를 logback 스타일(`log/debug/info/warn/error`) 로 정리하고 출력 포맷도 `yyyy-MM-dd HH:mm:ss.SSS LEVEL [thread] message` 표준 포맷으로 변경. logcat tag 도 FQCN(잘림) → \`NaviToTesla\` 로 단축.

부가로:
- `Application.onCreate` 의 RemoteConfig/AppCheck/Places/TokenWorker 초기화를 단일 IO 코루틴으로 묶음 (architectural hygiene)
- `ExampleInstrumentedTest` 가 `applicationIdSuffix=\".debug\"` 환경에서도 통과하도록 `BuildConfig.APPLICATION_ID` 기반 비교로 수정
- ktlint 1.8.0 에서 새로 잡힌 `ShareRequest.kt:20` dangling toplevel KDoc → block comment 로 변경

## Changes per commit

- \`refactor(AnalysisUtil)\` — 배치 writer + 100KB 롤링 + 표준 로그 포맷
- \`refactor(Application)\` — Firebase init 을 단일 IO 코루틴으로 묶음
- \`fix(test)\` — ExampleInstrumentedTest 를 BuildConfig.APPLICATION_ID 기준으로 수정
- \`style\` — ShareRequest dangling KDoc → block comment

## ANR 측정 결과 (참고)

`Application.onCreate` 변경 전후 cold-start A/B (SM-T225N, sdk=34, 각 3회):

| | WaitTime 평균 | Skipped frames 평균 |
|---|---:|---:|
| 변경 전 | 2657ms | ~88 |
| 변경 후 | 2751ms | ~95 |

cold-start 시간/프레임 드롭은 측정 노이즈 수준에서 변화 없음 또는 미세하게 나빠짐. 실제 메인스레드 블로커는 `MainActivity.onCreate` → `HomeFragment` 단계에 있다고 판단(별도 작업). Application init 비차단화 자체는 회귀 없는 코드 위생 개선이라 유지.

## Test plan

- [x] `./gradlew :app:compileNostoreDebugKotlin :app:compileNostoreDebugAndroidTestJavaWithJavac :app:testNostoreDebugUnitTest` 통과
- [x] `./gradlew :app:ktlintCheck` 통과
- [x] nostoreDebug 디바이스 설치 후 콜드스타트 3회 — 크래시/회귀 없음, AnalysisUtil 새 포맷으로 로그 정상 기록
- [ ] CI build-test / lint 잡 그린