### PR TITLE
perf: cold-start 메인스레드 차단 정리

### DIFF
--- a/app/src/main/kotlin/me/zipi/navitotesla/Application.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/Application.kt
@@ -6,6 +6,8 @@ import com.google.android.libraries.places.api.Places
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import me.zipi.navitotesla.background.TokenWorker
 import me.zipi.navitotesla.db.AppDatabase
@@ -20,7 +22,7 @@ import java.util.Locale
 class Application : Application() {
     override fun onCreate() {
         super.onCreate()
-        PreferencesUtil.initialize(this.applicationContext)
+        // 메인에서는 가벼운 init 만 (lazy/in-memory). PreferencesUtil 의 무거운 부분은 IO 로 위임.
         AppDatabase.initialize(this.applicationContext)
         AppRepository.initialize(database)
         AnalysisUtil.initialize(this.applicationContext)
@@ -30,9 +32,14 @@ class Application : Application() {
         )
         FirebaseCrashlytics.getInstance().isCrashlyticsCollectionEnabled = !BuildConfig.DEBUG
 
-        CoroutineScope(Dispatchers.IO).launch {
-            RemoteConfigUtil.initialize()
-            AppCheckUtil.initialize()
+        CoroutineScope(Dispatchers.IO + SupervisorJob()).launch {
+            // 서로 독립인 init 들 — 병렬 실행
+            listOf(
+                launch { PreferencesUtil.initialize(applicationContext) },
+                launch { RemoteConfigUtil.initialize() },
+                launch { AppCheckUtil.initialize() },
+            ).joinAll()
+            // RemoteConfig 의존 → 순차
             if (BuildConfig.DEBUG || BuildConfig.BUILD_MODE == "playstore") {
                 initializePlacesSdk()
             }

--- a/app/src/main/kotlin/me/zipi/navitotesla/Application.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/Application.kt
@@ -22,7 +22,6 @@ import java.util.Locale
 class Application : Application() {
     override fun onCreate() {
         super.onCreate()
-        // 메인에서는 가벼운 init 만 (lazy/in-memory). PreferencesUtil 의 무거운 부분은 IO 로 위임.
         AppDatabase.initialize(this.applicationContext)
         AppRepository.initialize(database)
         AnalysisUtil.initialize(this.applicationContext)
@@ -33,13 +32,11 @@ class Application : Application() {
         FirebaseCrashlytics.getInstance().isCrashlyticsCollectionEnabled = !BuildConfig.DEBUG
 
         CoroutineScope(Dispatchers.IO + SupervisorJob()).launch {
-            // 서로 독립인 init 들 — 병렬 실행
             listOf(
                 launch { PreferencesUtil.initialize(applicationContext) },
                 launch { RemoteConfigUtil.initialize() },
                 launch { AppCheckUtil.initialize() },
             ).joinAll()
-            // RemoteConfig 의존 → 순차
             if (BuildConfig.DEBUG || BuildConfig.BUILD_MODE == "playstore") {
                 initializePlacesSdk()
             }

--- a/app/src/main/kotlin/me/zipi/navitotesla/ui/home/HomeFragment.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/ui/home/HomeFragment.kt
@@ -102,8 +102,10 @@ class HomeFragment :
 
     override fun onResume() {
         super.onResume()
-        accessibilityGrantedCheck()
-        permissionNotificationListenerGrantedCheck()
+        lifecycleScope.launch {
+            accessibilityGrantedCheck()
+            permissionNotificationListenerGrantedCheck()
+        }
         lifecycleScope.launch(Dispatchers.Default) {
             launch { updateVersion() }
             launch { updateToken() }
@@ -147,31 +149,36 @@ class HomeFragment :
 
     private var permissionAlertDialog: AlertDialog? = null
 
-    private fun accessibilityGrantedCheck() {
+    private suspend fun accessibilityGrantedCheck() {
         if (nextAction == null) {
             return
         }
-        if (nextAction == "requireAccessibility") {
-            if (context == null) {
-                return
-            }
-            if (permissionAlertDialog != null && permissionAlertDialog!!.isShowing) {
-                return
-            }
-
-            // accessibility check
-            if (!NaviToTeslaAccessibilityService.isAccessibilityServiceEnabled(context)) {
-                permissionAlertDialog =
-                    AlertDialog
-                        .Builder(requireContext())
-                        .setTitle(getString(R.string.requireAccessibility))
-                        .setMessage(getString(R.string.guideRequireAccessibility))
-                        .setPositiveButton(getString(R.string.confirm)) { _: DialogInterface?, _: Int -> }
-                        .setCancelable(true)
-                        .show()
-                nextAction = null
-            }
+        if (nextAction != "requireAccessibility") {
+            return
         }
+        if (context == null) {
+            return
+        }
+        if (permissionAlertDialog != null && permissionAlertDialog!!.isShowing) {
+            return
+        }
+
+        val enabled =
+            withContext(Dispatchers.IO) {
+                NaviToTeslaAccessibilityService.isAccessibilityServiceEnabled(context)
+            }
+        if (enabled) {
+            return
+        }
+        permissionAlertDialog =
+            AlertDialog
+                .Builder(requireContext())
+                .setTitle(getString(R.string.requireAccessibility))
+                .setMessage(getString(R.string.guideRequireAccessibility))
+                .setPositiveButton(getString(R.string.confirm)) { _: DialogInterface?, _: Int -> }
+                .setCancelable(true)
+                .show()
+        nextAction = null
     }
 
     private suspend fun permissionGrantedCheck() {
@@ -217,7 +224,7 @@ class HomeFragment :
         }
     }
 
-    private fun permissionNotificationListenerGrantedCheck() {
+    private suspend fun permissionNotificationListenerGrantedCheck() {
         if (context == null) {
             return
         }
@@ -227,9 +234,9 @@ class HomeFragment :
 
         // notification listener
         val sets =
-            NotificationManagerCompat.getEnabledListenerPackages(
-                requireContext(),
-            )
+            withContext(Dispatchers.IO) {
+                NotificationManagerCompat.getEnabledListenerPackages(requireContext())
+            }
         if (!sets.contains(requireContext().packageName)) {
             permissionAlertDialog =
                 AlertDialog

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/PreferencesUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/PreferencesUtil.kt
@@ -19,10 +19,6 @@ object PreferencesUtil {
     private val initLatch = CountDownLatch(1)
     private val initStarted = AtomicBoolean(false)
 
-    /**
-     * Heavy init (Keystore MasterKey + EncryptedSharedPreferences) 을 백그라운드로 옮기는 진입점.
-     * 호출 측이 코루틴 스코프에서 launch 하면 됨. sync 접근 (loadTokenSync 등) 은 latch 대기.
-     */
     suspend fun initialize(applicationContext: Context) {
         if (!initStarted.compareAndSet(false, true)) {
             withContext(Dispatchers.IO) { initLatch.await() }

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/PreferencesUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/PreferencesUtil.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import me.zipi.navitotesla.model.Token
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.atomic.AtomicBoolean
 
 object PreferencesUtil {
     private const val PREFERENCES_FILE_NAME = "settings"
@@ -17,13 +16,9 @@ object PreferencesUtil {
     @Volatile
     private var instance: SharedPreferences? = null
     private val initLatch = CountDownLatch(1)
-    private val initStarted = AtomicBoolean(false)
 
     suspend fun initialize(applicationContext: Context) {
-        if (!initStarted.compareAndSet(false, true)) {
-            withContext(Dispatchers.IO) { initLatch.await() }
-            return
-        }
+        if (instance != null) return
         try {
             withContext(Dispatchers.IO) {
                 val masterKey =

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/PreferencesUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/PreferencesUtil.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import me.zipi.navitotesla.model.Token
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicBoolean
 
 object PreferencesUtil {
     private const val PREFERENCES_FILE_NAME = "settings"
@@ -16,38 +17,38 @@ object PreferencesUtil {
     @Volatile
     private var instance: SharedPreferences? = null
     private val initLatch = CountDownLatch(1)
+    private val initStarted = AtomicBoolean(false)
 
-    @Volatile
-    private var initStarted = false
-
-    @Synchronized
-    fun initialize(applicationContext: Context) {
-        if (initStarted) return
-        initStarted = true
-        Thread(
-            {
-                try {
-                    val masterKey =
-                        MasterKey
-                            .Builder(applicationContext)
-                            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-                            .build()
-                    instance =
-                        EncryptedSharedPreferences.create(
-                            applicationContext,
-                            PREFERENCES_FILE_NAME,
-                            masterKey,
-                            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
-                        )
-                } catch (e: Exception) {
-                    AnalysisUtil.recordException(e)
-                } finally {
-                    initLatch.countDown()
-                }
-            },
-            "PreferencesUtil-init",
-        ).start()
+    /**
+     * Heavy init (Keystore MasterKey + EncryptedSharedPreferences) 을 백그라운드로 옮기는 진입점.
+     * 호출 측이 코루틴 스코프에서 launch 하면 됨. sync 접근 (loadTokenSync 등) 은 latch 대기.
+     */
+    suspend fun initialize(applicationContext: Context) {
+        if (!initStarted.compareAndSet(false, true)) {
+            withContext(Dispatchers.IO) { initLatch.await() }
+            return
+        }
+        try {
+            withContext(Dispatchers.IO) {
+                val masterKey =
+                    MasterKey
+                        .Builder(applicationContext)
+                        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                        .build()
+                instance =
+                    EncryptedSharedPreferences.create(
+                        applicationContext,
+                        PREFERENCES_FILE_NAME,
+                        masterKey,
+                        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+                    )
+            }
+        } catch (e: Exception) {
+            AnalysisUtil.recordException(e)
+        } finally {
+            initLatch.countDown()
+        }
     }
 
     private fun prefs(): SharedPreferences {

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/PreferencesUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/PreferencesUtil.kt
@@ -8,39 +8,58 @@ import androidx.security.crypto.MasterKey
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import me.zipi.navitotesla.model.Token
-import java.io.IOException
-import java.security.GeneralSecurityException
+import java.util.concurrent.CountDownLatch
 
 object PreferencesUtil {
-    private lateinit var instance: SharedPreferences
+    private const val PREFERENCES_FILE_NAME = "settings"
 
-    @Throws(GeneralSecurityException::class, IOException::class)
+    @Volatile
+    private var instance: SharedPreferences? = null
+    private val initLatch = CountDownLatch(1)
+
+    @Volatile
+    private var initStarted = false
+
+    @Synchronized
     fun initialize(applicationContext: Context) {
-        if (!this::instance.isInitialized) {
-            synchronized(PreferencesUtil::class) {
-                val masterKey =
-                    MasterKey
-                        .Builder(applicationContext)
-                        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-                        .build()
-                instance =
-                    EncryptedSharedPreferences.create(
-                        applicationContext,
-                        PREFERENCES_FILE_NAME,
-                        masterKey,
-                        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
-                    )
-            }
-        }
+        if (initStarted) return
+        initStarted = true
+        Thread(
+            {
+                try {
+                    val masterKey =
+                        MasterKey
+                            .Builder(applicationContext)
+                            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                            .build()
+                    instance =
+                        EncryptedSharedPreferences.create(
+                            applicationContext,
+                            PREFERENCES_FILE_NAME,
+                            masterKey,
+                            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+                        )
+                } catch (e: Exception) {
+                    AnalysisUtil.recordException(e)
+                } finally {
+                    initLatch.countDown()
+                }
+            },
+            "PreferencesUtil-init",
+        ).start()
     }
 
-    private const val PREFERENCES_FILE_NAME = "settings"
+    private fun prefs(): SharedPreferences {
+        instance?.let { return it }
+        initLatch.await()
+        return instance ?: error("PreferencesUtil initialization failed")
+    }
 
     suspend fun remove(key: String): Boolean =
         withContext(Dispatchers.IO) {
             try {
-                instance.edit { remove(key) }
+                prefs().edit { remove(key) }
                 true
             } catch (e: Exception) {
                 AnalysisUtil.warn("remove  error", e)
@@ -52,7 +71,7 @@ object PreferencesUtil {
     suspend fun clear() {
         withContext(Dispatchers.IO) {
             try {
-                instance.edit { clear() }
+                prefs().edit { clear() }
             } catch (e: Exception) {
                 AnalysisUtil.warn("clear error", e)
                 AnalysisUtil.recordException(e)
@@ -66,7 +85,7 @@ object PreferencesUtil {
     ): Boolean =
         withContext(Dispatchers.IO) {
             try {
-                instance.edit { putBoolean(key, value) }
+                prefs().edit { putBoolean(key, value) }
                 true
             } catch (e: Exception) {
                 AnalysisUtil.warn("put boolean error", e)
@@ -81,7 +100,7 @@ object PreferencesUtil {
     ): Boolean =
         withContext(Dispatchers.IO) {
             try {
-                instance.edit { putLong(key, value) }
+                prefs().edit { putLong(key, value) }
                 true
             } catch (e: Exception) {
                 AnalysisUtil.warn("put long error", e)
@@ -96,7 +115,7 @@ object PreferencesUtil {
     ): Boolean =
         withContext(Dispatchers.IO) {
             try {
-                instance.edit { putString(key, value) }
+                prefs().edit { putString(key, value) }
                 true
             } catch (e: Exception) {
                 AnalysisUtil.warn("put string error", e)
@@ -111,7 +130,7 @@ object PreferencesUtil {
     ): String? =
         withContext(Dispatchers.IO) {
             try {
-                instance.getString(key, defaultValue)
+                prefs().getString(key, defaultValue)
             } catch (e: Exception) {
                 AnalysisUtil.warn("get string error", e)
                 AnalysisUtil.recordException(e)
@@ -124,7 +143,7 @@ object PreferencesUtil {
         defaultValue: String?,
     ): String? =
         try {
-            instance.getString(key, defaultValue)
+            prefs().getString(key, defaultValue)
         } catch (e: Exception) {
             AnalysisUtil.warn("get string error", e)
             AnalysisUtil.recordException(e)
@@ -133,17 +152,13 @@ object PreferencesUtil {
 
     suspend fun getString(key: String): String? = getString(key, null)
 
-//    fun getBoolean(context: Context?, key: String?): Boolean? {
-//        return getBoolean(context, key, null)
-//    }
-
     suspend fun getBoolean(
         key: String,
         defaultValue: Boolean,
     ): Boolean =
         withContext(Dispatchers.IO) {
             try {
-                instance.getBoolean(key, defaultValue)
+                prefs().getBoolean(key, defaultValue)
             } catch (e: Exception) {
                 AnalysisUtil.warn("get boolean error", e)
                 AnalysisUtil.recordException(e)
@@ -154,7 +169,7 @@ object PreferencesUtil {
     suspend fun getLong(key: String): Long? =
         withContext(Dispatchers.IO) {
             try {
-                val result = instance.getLong(key, -1)
+                val result = prefs().getLong(key, -1)
                 if (result == -1L) null else result
             } catch (e: Exception) {
                 AnalysisUtil.warn("get long error", e)
@@ -165,7 +180,7 @@ object PreferencesUtil {
 
     fun getLongSync(key: String): Long? =
         try {
-            val result = instance.getLong(key, -1)
+            val result = prefs().getLong(key, -1)
             if (result == -1L) null else result
         } catch (e: Exception) {
             AnalysisUtil.warn("get long error", e)
@@ -179,7 +194,7 @@ object PreferencesUtil {
     ): Long =
         withContext(Dispatchers.IO) {
             try {
-                instance.getLong(key, defaultValue)
+                prefs().getLong(key, defaultValue)
             } catch (e: Exception) {
                 AnalysisUtil.warn("get long error", e)
                 AnalysisUtil.recordException(e)


### PR DESCRIPTION
## 변경
- `PreferencesUtil.initialize` 가 `Application.onCreate` 메인에서 `MasterKey` + `EncryptedSharedPreferences.create()` 동기 실행하던 걸 백그라운드 코루틴 + `CountDownLatch` 로 분리.
- `HomeFragment.onResume` 의 `accessibilityGrantedCheck` / `permissionNotificationListenerGrantedCheck` 가 `Settings.Secure.getString` / `NotificationManagerCompat.getEnabledListenerPackages` 를 메인에서 호출하던 걸 `suspend` + `withContext(Dispatchers.IO)` 로 변경. AlertDialog 표시는 Main 유지.
- `Application.onCreate` 의 독립 init (PreferencesUtil / RemoteConfig / AppCheck) 을 IO 스코프 안 `joinAll` 로 병렬 실행. RemoteConfig 의존하는 Places SDK init 은 그 뒤 순차.

## 측정 (SM-T225N, Android 14, cold-start 3회)
- WaitTime 평균: 2753ms → 2617ms
- Skipped frames 합: ~91 → ~33

## 검증 (로컬)
- `./gradlew :app:compileNostoreDebugKotlin :app:testNostoreDebugUnitTest :app:ktlintCheck` ✅
- 디바이스 cold-start 3회 — 권한 다이얼로그/토큰 입력 회귀 없음