### PR TITLE
chore: App Check 토큰 스크립트 + 주소 해결 로그 추가

### DIFF
--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
@@ -22,21 +22,33 @@ object DestinationAddressResolver {
         val roadAddress = poi.getRoadAddress()
         val jibunAddress = poi.getAddress()
         val eventParam = Bundle().apply { putString("package", poi.packageName) }
+        AnalysisUtil.debug("resolve start: poi='$poiName', pkg=${poi.packageName}")
 
         val dao = AppDatabase.getInstance().poiAddressDao()
         val cached = dao.findPoiByPackage(poiName, poi.packageName)
         if (cached != null && !cached.isExpire) {
-            cached.sentAddress?.let { return it }
+            cached.sentAddress?.let {
+                AnalysisUtil.debug("resolve: local cache hit, sentMode=${cached.sentMode}")
+                return it
+            }
         }
 
         val firebaseDisabledFlavor = !BuildConfig.DEBUG && BuildConfig.BUILD_MODE != "playstore"
         if (firebaseDisabledFlavor || jibunAddress.isEmpty() || jibunAddress == roadAddress) {
+            val reason =
+                when {
+                    firebaseDisabledFlavor -> "flavor"
+                    jibunAddress.isEmpty() -> "no_jibun"
+                    else -> "jibun=road"
+                }
+            AnalysisUtil.debug("resolve: skip firestore/places ($reason), using road")
             AppRepository.getInstance().markSent(poi, PoiAddressEntity.SENT_MODE_ROAD)
             return roadAddress
         }
 
         val lookupEnabled = RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED)
         if (!lookupEnabled) {
+            AnalysisUtil.debug("resolve: lookup disabled by RC, using road")
             AppRepository.getInstance().markSent(poi, PoiAddressEntity.SENT_MODE_ROAD)
             return roadAddress
         }
@@ -44,6 +56,7 @@ object DestinationAddressResolver {
         AnalysisUtil.logEvent("firestore_get", eventParam)
         when (cacheClient.lookup(roadAddress)) {
             PlaceAutocompleteCacheEntry.Searchable -> {
+                AnalysisUtil.debug("resolve: firestore hit=searchable, using road")
                 AnalysisUtil.logEvent(
                     "firestore_hit",
                     Bundle().apply {
@@ -56,6 +69,7 @@ object DestinationAddressResolver {
             }
 
             PlaceAutocompleteCacheEntry.NotSearchable -> {
+                AnalysisUtil.debug("resolve: firestore hit=not_searchable, using jibun")
                 AnalysisUtil.logEvent(
                     "firestore_hit",
                     Bundle().apply {
@@ -68,12 +82,13 @@ object DestinationAddressResolver {
             }
 
             null -> {
-                // miss → 다음 단계
+                AnalysisUtil.debug("resolve: firestore miss")
             }
         }
 
         val updateEnabled = RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_ENABLED)
         if (!updateEnabled) {
+            AnalysisUtil.debug("resolve: update disabled by RC, using road")
             AppRepository.getInstance().markSent(poi, PoiAddressEntity.SENT_MODE_ROAD)
             return roadAddress
         }
@@ -88,10 +103,13 @@ object DestinationAddressResolver {
                 AnalysisUtil.recordException(e)
                 null
             }
+        AnalysisUtil.debug("resolve: places_api match=$matched")
 
         return if (matched == null) {
+            AnalysisUtil.debug("resolve: places error, using road (no cache set)")
             roadAddress
         } else if (matched) {
+            AnalysisUtil.debug("resolve: cache set=searchable, using road")
             AnalysisUtil.logEvent(
                 "firestore_set",
                 Bundle().apply {
@@ -103,6 +121,7 @@ object DestinationAddressResolver {
             AppRepository.getInstance().markSent(poi, PoiAddressEntity.SENT_MODE_ROAD)
             roadAddress
         } else {
+            AnalysisUtil.debug("resolve: cache set=not_searchable, using jibun")
             AnalysisUtil.logEvent(
                 "firestore_set",
                 Bundle().apply {

--- a/scripts/appcheck-debug-token.sh
+++ b/scripts/appcheck-debug-token.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# adb logcat 에서 Firebase App Check debug token 을 추출한다.
+# debug 빌드에서 AppCheckUtil.initialize 가 호출되면 logcat 에
+#   "Enter this debug secret into the allow list ... : <UUID>"
+# 가 한 줄 출력되는데, 그걸 캡쳐해서 stdout 으로 토큰만 내보낸다.
+#
+# 사용법:
+#   scripts/appcheck-debug-token.sh
+#   scripts/appcheck-debug-token.sh --restart
+#   APP_PACKAGE=me.zipi.navitotesla.debug scripts/appcheck-debug-token.sh
+#
+# 옵션:
+#   --restart              앱을 강제 종료한 뒤 다시 띄워서 새로 토큰 출력 유도
+#   --target <pkg>         대상 앱 패키지
+#                          default: me.zipi.navitotesla.ns.debug (nostore debug)
+#                          playstore debug 는 me.zipi.navitotesla.debug
+#   --timeout <초>         토큰 캡쳐 대기 시간 (default: 30)
+#   -h, --help             이 도움말
+
+set -euo pipefail
+
+TARGET_PKG="${APP_PACKAGE:-me.zipi.navitotesla.ns.debug}"
+RESTART=0
+TIMEOUT=30
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --restart)
+            RESTART=1
+            shift
+            ;;
+        --target)
+            TARGET_PKG="$2"
+            shift 2
+            ;;
+        --timeout)
+            TIMEOUT="$2"
+            shift 2
+            ;;
+        -h|--help)
+            sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            echo "알 수 없는 옵션: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if ! adb get-state >/dev/null 2>&1; then
+    echo "adb 디바이스가 연결되어 있지 않음." >&2
+    exit 1
+fi
+
+PATTERN='Enter this debug secret into the allow list in the Firebase Console for your project: '
+
+# 1) 현재 logcat buffer 에 이미 있으면 그대로 사용
+if [[ "$RESTART" -eq 0 ]]; then
+    EXISTING=$(adb logcat -d 2>/dev/null | grep -F "$PATTERN" | tail -1 || true)
+    if [[ -n "$EXISTING" ]]; then
+        echo "${EXISTING##*: }"
+        exit 0
+    fi
+fi
+
+# 2) 없거나 --restart 인 경우 앱 재시작 후 logcat tail
+echo "logcat buffer 에 토큰 없음 — $TARGET_PKG 재시작 후 ${TIMEOUT}s 대기" >&2
+adb shell am force-stop "$TARGET_PKG"
+adb logcat -c
+adb shell monkey -p "$TARGET_PKG" -c android.intent.category.LAUNCHER 1 >/dev/null 2>&1
+
+DEADLINE=$(( $(date +%s) + TIMEOUT ))
+while (( $(date +%s) < DEADLINE )); do
+    LINE=$(adb logcat -d 2>/dev/null | grep -F "$PATTERN" | tail -1 || true)
+    if [[ -n "$LINE" ]]; then
+        echo "${LINE##*: }"
+        exit 0
+    fi
+    sleep 1
+done
+
+echo "토큰을 ${TIMEOUT}초 안에 찾지 못함." >&2
+echo "  - debug 빌드인지 확인 (src/debug/.../AppCheckUtil.kt 실행 경로)" >&2
+echo "  - $TARGET_PKG 패키지명이 맞는지 확인" >&2
+exit 1


### PR DESCRIPTION
## 변경
- `scripts/appcheck-debug-token.sh` — adb logcat 에서 Firebase App Check debug token 캡쳐. 기본은 buffer 에서 grep, 없으면 앱 재시작 후 30s 대기. `--restart` / `--target` / `--timeout` / `APP_PACKAGE` 지원.
- `DestinationAddressResolver.resolve` 각 분기에 `AnalysisUtil.debug` 추가. 로컬 캐시 hit, flavor/RC skip 사유, firestore hit·miss, places API match true/false/null, 최종 사용 모드를 file log 에서 따라갈 수 있음.

## 검증 (로컬)
- `./gradlew :app:compileNostoreDebugKotlin :app:testNostoreDebugUnitTest :app:ktlintCheck` ✅
- 스크립트 buffer hit / `--restart` / `--help` 동작 확인 (SM-T225N)