### PR TITLE
fix(AppUpdaterUtil): 버전 비교 / 다이얼로그 중복 버그

### DIFF
--- a/app/src/main/kotlin/me/zipi/navitotesla/util/AppUpdaterUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/AppUpdaterUtil.kt
@@ -27,7 +27,6 @@ import me.zipi.navitotesla.model.Github.Release
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-import java.lang.Float.parseFloat
 import java.net.HttpURLConnection
 import java.net.URL
 import java.util.concurrent.TimeUnit
@@ -84,6 +83,7 @@ object AppUpdaterUtil {
             if (!isForce && (abs(System.currentTimeMillis() - dialogLastCheck) < 5 * 60 * 1000 || isDoNotShow())) {
                 return@withContext
             }
+            dialogLastCheck = System.currentTimeMillis()
             if (isUpdateAvailable(activity)) {
                 if (!permissionCheck(activity)) {
                     return@withContext
@@ -136,7 +136,6 @@ object AppUpdaterUtil {
                         .show()
 
                     permissionCheck(activity)
-                    dialogLastCheck = System.currentTimeMillis()
                     ResponseCloser.closeAll(response)
                 } catch (e: Exception) {
                     AnalysisUtil.warn("error update dialog show", e)
@@ -273,20 +272,27 @@ object AppUpdaterUtil {
     }
 
     suspend fun isUpdateAvailable(context: Context?): Boolean {
-        var latestVersionNumber = 1.0f
-        var currentVersionNumber = 1.0f
         val latestVersion = getLatestVersion()
+        if (latestVersion == "1.0") return false
         val currentVersion = getCurrentVersion(context)
-        if (latestVersion.contains(".")) {
-            latestVersionNumber =
-                parseFloat(latestVersion.split("[.-]".toRegex())[0] + "." + latestVersion.split("[.-]".toRegex())[1])
-        }
-        if (currentVersion.contains(".")) {
-            currentVersionNumber =
-                parseFloat(currentVersion.split("[.-]".toRegex())[0] + "." + currentVersion.split("[.-]".toRegex())[1])
-        }
-        return latestVersion != "1.0" && currentVersionNumber < latestVersionNumber
+        return compareVersion(currentVersion, latestVersion) < 0
     }
+
+    internal fun compareVersion(
+        a: String,
+        b: String,
+    ): Int {
+        val ap = parseVersion(a)
+        val bp = parseVersion(b)
+        for (i in 0 until maxOf(ap.size, bp.size)) {
+            val l = ap.getOrNull(i) ?: 0
+            val r = bp.getOrNull(i) ?: 0
+            if (l != r) return l.compareTo(r)
+        }
+        return 0
+    }
+
+    private fun parseVersion(v: String): List<Int> = v.split(Regex("[.-]")).mapNotNull { it.toIntOrNull() }
 
     private fun permissionCheck(activity: Activity): Boolean {
         // playstore 빌드는 자체 APK 다운로드 경로가 없어 외부 저장소 권한 자체가 불필요.
@@ -330,6 +336,7 @@ object AppUpdaterUtil {
         if (abs(System.currentTimeMillis() - notificationLastCheck) < 5 * 60 * 1000 || isDoNotShow()) {
             return
         }
+        notificationLastCheck = System.currentTimeMillis()
         if (isUpdateAvailable(context)) {
             val notificationManager =
                 context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -361,7 +368,6 @@ object AppUpdaterUtil {
                     .build()
             notificationManager.notify(0, notification)
         }
-        notificationLastCheck = System.currentTimeMillis()
     }
 
     private fun isPlayStoreInstalled(context: Context): Boolean =

--- a/app/src/test/kotlin/me/zipi/navitotesla/util/AppUpdaterUtilCompareVersionTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/util/AppUpdaterUtilCompareVersionTest.kt
@@ -1,0 +1,56 @@
+package me.zipi.navitotesla.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AppUpdaterUtilCompareVersionTest {
+    @Test
+    fun `1_98 is older than 1_100 (lexicographic minor)`() {
+        assertTrue(AppUpdaterUtil.compareVersion("1.98", "1.100") < 0)
+    }
+
+    @Test
+    fun `1_100 is newer than 1_98`() {
+        assertTrue(AppUpdaterUtil.compareVersion("1.100", "1.98") > 0)
+    }
+
+    @Test
+    fun `equal versions return 0`() {
+        assertEquals(0, AppUpdaterUtil.compareVersion("1.91", "1.91"))
+    }
+
+    @Test
+    fun `suffix like -debug or sha8 is ignored`() {
+        assertEquals(0, AppUpdaterUtil.compareVersion("1.100-debug", "1.100"))
+        assertEquals(0, AppUpdaterUtil.compareVersion("1.100.abc12345", "1.100"))
+    }
+
+    @Test
+    fun `2_x is newer than 1_x`() {
+        assertTrue(AppUpdaterUtil.compareVersion("1.999", "2.0") < 0)
+    }
+
+    @Test
+    fun `2_00 is newer than 1_100 (major bump overrides large minor)`() {
+        assertTrue(AppUpdaterUtil.compareVersion("2.00", "1.100") > 0)
+        assertTrue(AppUpdaterUtil.compareVersion("1.100", "2.00") < 0)
+    }
+
+    @Test
+    fun `2_100 is newer than 1_100 (same minor, major bump wins)`() {
+        assertTrue(AppUpdaterUtil.compareVersion("2.100", "1.100") > 0)
+        assertTrue(AppUpdaterUtil.compareVersion("1.100", "2.100") < 0)
+    }
+
+    @Test
+    fun `different commit hash on same version is equal`() {
+        assertEquals(0, AppUpdaterUtil.compareVersion("1.100.asdf", "1.100.efgh"))
+    }
+
+    @Test
+    fun `commit hash suffix does not affect major-minor comparison`() {
+        assertTrue(AppUpdaterUtil.compareVersion("1.98.abc12345", "1.100.def67890") < 0)
+        assertTrue(AppUpdaterUtil.compareVersion("2.0.aaaaaaaa", "1.999.zzzzzzzz") > 0)
+    }
+}


### PR DESCRIPTION
## 변경
- 버전 비교가 `parseFloat("1.100") = 1.1f`, `parseFloat("1.98") = 1.98f` 로 처리되면서 `1.100` 디바이스에서 `1.98` 을 최신으로 보고 잘못된 업데이트 알림이 떴음. `.` / `-` 로 split 한 정수 리스트의 lexicographic 비교로 교체. `1.100.abc12345` 같은 commit hash suffix 는 `toIntOrNull` 로 자연 무시.
- `dialog` / `notification` 의 throttle 갱신 (`dialogLastCheck` / `notificationLastCheck`) 이 함수 끝/다이얼로그 표시 직후라, GitHub API 호출 (~1-2s) 도중 onResume 가 두 번 호출되면 두 호출 모두 가드 통과 → 다이얼로그 2개 표시. 진입 직후로 갱신 시점 이동.

## 테스트
`AppUpdaterUtilCompareVersionTest` 9건:
- `1.98 < 1.100`, 역방향
- 동일 버전
- `-debug` / `.sha8` suffix 무시
- `1.999 < 2.0` major bump
- `2.00 > 1.100`, `2.100 > 1.100`
- 같은 버전 다른 hash (`1.100.asdf == 1.100.efgh`)
- hash 있는 채로 major-minor 비교

## 검증 (로컬)
- `./gradlew :app:testNostoreDebugUnitTest :app:ktlintCheck` ✅