### PR TITLE
feat(remote-config): Google Place update API 호출 샘플링 비율 추가

### DIFF
--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
@@ -8,6 +8,7 @@ import me.zipi.navitotesla.db.AppDatabase
 import me.zipi.navitotesla.model.Poi
 import me.zipi.navitotesla.util.AnalysisUtil
 import me.zipi.navitotesla.util.RemoteConfigUtil
+import kotlin.random.Random
 
 object DestinationAddressResolver {
     @Volatile
@@ -77,6 +78,12 @@ object DestinationAddressResolver {
         val updateEnabled = RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_ENABLED)
         if (!updateEnabled) {
             AnalysisUtil.debug("classify: places update disabled by RC, unknown")
+            return Searchability.Unknown
+        }
+
+        val ratio = RemoteConfigUtil.getLong(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_RATIO).coerceIn(0L, 100L).toInt()
+        if (Random.nextInt(100) >= ratio) {
+            AnalysisUtil.debug("classify: places update sampled out (ratio=$ratio), unknown")
             return Searchability.Unknown
         }
 

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/RemoteConfigUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/RemoteConfigUtil.kt
@@ -8,6 +8,7 @@ import me.zipi.navitotesla.R
 object RemoteConfigUtil {
     const val KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED = "googlePlaceCheckLookupEnabled"
     const val KEY_GOOGLE_PLACE_CHECK_UPDATE_ENABLED = "googlePlaceCheckUpdateEnabled"
+    const val KEY_GOOGLE_PLACE_CHECK_UPDATE_RATIO = "googlePlaceCheckUpdateRatio"
     const val KEY_GOOGLE_PLACES_API_KEY = "googlePlacesApiKey"
     const val KEY_GOOGLE_PLACE_CHECK_TTL_DAYS = "googlePlaceCheckTtlDays"
     const val KEY_SEND_UNKNOWN_AS_NOT_SEARCHABLE = "sendUnknownAsNotSearchable"

--- a/app/src/main/res/xml/remote_config_defaults.xml
+++ b/app/src/main/res/xml/remote_config_defaults.xml
@@ -29,6 +29,10 @@
         <value>false</value>
     </entry>
     <entry>
+        <key>googlePlaceCheckUpdateRatio</key>
+        <value>100</value>
+    </entry>
+    <entry>
         <key>googlePlacesApiKey</key>
         <value>default</value>
     </entry>


### PR DESCRIPTION
## Summary
- `googlePlaceCheckUpdateEnabled=true` 상태에서 Places API 를 100% 호출하지 않고 신규 Remote Config `googlePlaceCheckUpdateRatio` (0–100) 비율만큼만 호출하도록 샘플링 추가.
- 기존 `naverApiRatio` 와 동일하게 `Random.nextInt(100) < ratio` 방식. 범위 밖 값은 `coerceIn(0, 100)` 으로 클램프.
- 기본값 `100` — 기존 동작(전량 호출) 유지. Firebase 콘솔에서 낮추면 throttling 가능.

## 변경 내역
- `RemoteConfigUtil`: `KEY_GOOGLE_PLACE_CHECK_UPDATE_RATIO` 상수 추가
- `remote_config_defaults.xml`: 기본값 `100`
- `DestinationAddressResolver.classify`: `updateEnabled` 통과 후 ratio 샘플링 분기 추가 — 샘플 아웃되면 캐시 저장 없이 `Searchability.Unknown` 반환 (= `updateEnabled=false` 경로와 동일)

## Test plan
- [x] `:app:compilePlaystoreDebugKotlin` 통과
- [x] 기존 `DestinationAddressResolverClassifyTest` 통과 (모든 케이스가 ratio 분기 이전에 종료되어 영향 없음)
- [ ] Firebase Remote Config 에서 `googlePlaceCheckUpdateRatio=10` 으로 설정 후 places_api_call 이벤트 비율 확인