### PR TITLE
feat(place): Place API 24h 쿨다운 + 사용순 캐시 정리

### DIFF
--- a/app/schemas/me.zipi.navitotesla.db.AppDatabase/11.json
+++ b/app/schemas/me.zipi.navitotesla.db.AppDatabase/11.json
@@ -1,0 +1,150 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 11,
+    "identityHash": "69e92838342d40b93184ddad8fa822de",
+    "entities": [
+      {
+        "tableName": "poi_address",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `poi` TEXT NOT NULL, `packageName` TEXT, `roadAddress` TEXT, `jibunAddress` TEXT, `latitude` TEXT, `longitude` TEXT, `registered` INTEGER, `isDuplicate` INTEGER, `sentMode` TEXT, `searchable` INTEGER, `created` INTEGER, `lastCheckedAt` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "poi",
+            "columnName": "poi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "roadAddress",
+            "columnName": "roadAddress",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "jibunAddress",
+            "columnName": "jibunAddress",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "registered",
+            "columnName": "registered",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isDuplicate",
+            "columnName": "isDuplicate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sentMode",
+            "columnName": "sentMode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "searchable",
+            "columnName": "searchable",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastCheckedAt",
+            "columnName": "lastCheckedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_poi_address_poi_packageName",
+            "unique": true,
+            "columnNames": [
+              "poi",
+              "packageName"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_poi_address_poi_packageName` ON `${TABLE_NAME}` (`poi`, `packageName`)"
+          }
+        ]
+      },
+      {
+        "tableName": "condition",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `created` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_condition_type_name",
+            "unique": true,
+            "columnNames": [
+              "type",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_condition_type_name` ON `${TABLE_NAME}` (`type`, `name`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '69e92838342d40b93184ddad8fa822de')"
+    ]
+  }
+}

--- a/app/schemas/me.zipi.navitotesla.db.AppDatabase/12.json
+++ b/app/schemas/me.zipi.navitotesla.db.AppDatabase/12.json
@@ -1,0 +1,155 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 12,
+    "identityHash": "11d3052df6c21a4e104a1a609a49b8be",
+    "entities": [
+      {
+        "tableName": "poi_address",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `poi` TEXT NOT NULL, `packageName` TEXT, `roadAddress` TEXT, `jibunAddress` TEXT, `latitude` TEXT, `longitude` TEXT, `registered` INTEGER, `isDuplicate` INTEGER, `sentMode` TEXT, `searchable` INTEGER, `created` INTEGER, `lastCheckedAt` INTEGER, `lastUsedAt` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "poi",
+            "columnName": "poi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "roadAddress",
+            "columnName": "roadAddress",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "jibunAddress",
+            "columnName": "jibunAddress",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "registered",
+            "columnName": "registered",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isDuplicate",
+            "columnName": "isDuplicate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sentMode",
+            "columnName": "sentMode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "searchable",
+            "columnName": "searchable",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastCheckedAt",
+            "columnName": "lastCheckedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUsedAt",
+            "columnName": "lastUsedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_poi_address_poi_packageName",
+            "unique": true,
+            "columnNames": [
+              "poi",
+              "packageName"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_poi_address_poi_packageName` ON `${TABLE_NAME}` (`poi`, `packageName`)"
+          }
+        ]
+      },
+      {
+        "tableName": "condition",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `created` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_condition_type_name",
+            "unique": true,
+            "columnNames": [
+              "type",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_condition_type_name` ON `${TABLE_NAME}` (`type`, `name`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '11d3052df6c21a4e104a1a609a49b8be')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
@@ -6,6 +6,7 @@ import me.zipi.navitotesla.api.TeslaAuthApi
 import me.zipi.navitotesla.db.AppDatabase
 import me.zipi.navitotesla.db.PoiAddressEntity
 import me.zipi.navitotesla.model.Poi
+import me.zipi.navitotesla.service.place.Searchability
 import me.zipi.navitotesla.util.AnalysisUtil
 import me.zipi.navitotesla.util.HttpRetryInterceptor
 import me.zipi.navitotesla.util.PreferencesUtil
@@ -144,9 +145,15 @@ class AppRepository private constructor(
      */
     suspend fun markClassified(
         poi: Poi,
-        searchable: Boolean?,
+        searchability: Searchability,
     ) {
         val poiName = poi.poiName ?: return
+        val searchable: Boolean? =
+            when (searchability) {
+                Searchability.Searchable -> true
+                Searchability.NotSearchable -> false
+                Searchability.Unknown -> null
+            }
         database.withTransaction {
             val existing = database.poiAddressDao().findPoiByPackage(poiName, poi.packageName)
             database.poiAddressDao().insertPoi(

--- a/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
@@ -163,6 +163,7 @@ class AppRepository private constructor(
                     sentMode = existing?.sentMode, // 즐겨찾기 명시 mode 보존
                     searchable = searchable,
                     created = Date(),
+                    lastCheckedAt = System.currentTimeMillis(),
                 ),
             )
         }

--- a/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
@@ -138,11 +138,6 @@ class AppRepository private constructor(
         }
     }
 
-    /**
-     * Resolver 가 실제 Firestore/Places API 호출 결과를 기록할 때 호출.
-     * lastCheckedAt(cooldown anchor) 와 lastUsedAt(사용 시점) 둘 다 갱신.
-     * 기존 row 가 있으면 id/registered/sentMode/isDuplicate/created 유지.
-     */
     suspend fun markClassified(
         poi: Poi,
         searchability: Searchability,
@@ -168,7 +163,7 @@ class AppRepository private constructor(
                     longitude = poi.longitude,
                     registered = existing?.registered ?: false,
                     isDuplicate = existing?.isDuplicate ?: poi.isDuplicate,
-                    sentMode = existing?.sentMode, // 즐겨찾기 명시 mode 보존
+                    sentMode = existing?.sentMode,
                     searchable = searchable,
                     created = existing?.created ?: Date(),
                     lastCheckedAt = now,
@@ -178,10 +173,6 @@ class AppRepository private constructor(
         }
     }
 
-    /**
-     * Cache hit / cooldown skip 등 실제 API 호출이 발생하지 않은 사용 시점만 기록.
-     * lastUsedAt 만 갱신 — lastCheckedAt(cooldown anchor)는 보존.
-     */
     suspend fun touchLastUsed(poi: Poi) {
         val poiName = poi.poiName ?: return
         database.withTransaction {

--- a/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
@@ -175,37 +175,16 @@ class AppRepository private constructor(
 
     suspend fun touchLastUsed(poi: Poi) {
         val poiName = poi.poiName ?: return
-        database.withTransaction {
-            val existing = database.poiAddressDao().findPoiByPackage(poiName, poi.packageName) ?: return@withTransaction
-            database.poiAddressDao().insertPoi(
-                PoiAddressEntity(
-                    id = existing.id,
-                    poi = existing.poi,
-                    packageName = existing.packageName,
-                    roadAddress = existing.roadAddress,
-                    jibunAddress = existing.jibunAddress,
-                    latitude = existing.latitude,
-                    longitude = existing.longitude,
-                    registered = existing.registered,
-                    isDuplicate = existing.isDuplicate,
-                    sentMode = existing.sentMode,
-                    searchable = existing.searchable,
-                    created = existing.created,
-                    lastCheckedAt = existing.lastCheckedAt,
-                    lastUsedAt = System.currentTimeMillis(),
-                ),
-            )
-        }
+        database.poiAddressDao().updateLastUsedAt(poiName, poi.packageName, System.currentTimeMillis())
     }
 
     suspend fun clearExpiredPoi() {
-        // remove expire poi. (20% over)
         val ttlMs = PoiAddressEntity.EXPIRE_DAY.toLong() * 24L * 60L * 60L * 1000L
-        val expireDate = System.currentTimeMillis() - ttlMs * 12L / 10L
-        database.poiAddressDao().findExpired(expireDate).forEach { entity ->
-            database.withTransaction {
-                database.poiAddressDao().delete(entity)
-            }
+        val expireDate = System.currentTimeMillis() - ttlMs
+        try {
+            database.poiAddressDao().deleteExpired(expireDate)
+        } catch (e: Exception) {
+            AnalysisUtil.recordException(e)
         }
     }
 

--- a/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
@@ -169,7 +169,7 @@ class AppRepository private constructor(
                     isDuplicate = existing?.isDuplicate ?: poi.isDuplicate,
                     sentMode = existing?.sentMode, // 즐겨찾기 명시 mode 보존
                     searchable = searchable,
-                    created = Date(),
+                    created = existing?.created ?: Date(),
                     lastCheckedAt = System.currentTimeMillis(),
                 ),
             )

--- a/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
@@ -139,9 +139,9 @@ class AppRepository private constructor(
     }
 
     /**
-     * Resolver 가 검색 가능 여부 결정 후 호출. 기존 row 가 있으면 id/registered/sentMode/isDuplicate 유지하면서
-     * searchable 갱신. 없으면 신규 insert. 즐겨찾기(registered=true) row 의 sentMode 는 보존하고,
-     * 한번 isDuplicate=true 로 마킹된 row 는 stick (resolver 가 false 로 덮어쓰지 못함).
+     * Resolver 가 실제 Firestore/Places API 호출 결과를 기록할 때 호출.
+     * lastCheckedAt(cooldown anchor) 와 lastUsedAt(사용 시점) 둘 다 갱신.
+     * 기존 row 가 있으면 id/registered/sentMode/isDuplicate/created 유지.
      */
     suspend fun markClassified(
         poi: Poi,
@@ -154,6 +154,7 @@ class AppRepository private constructor(
                 Searchability.NotSearchable -> false
                 Searchability.Unknown -> null
             }
+        val now = System.currentTimeMillis()
         database.withTransaction {
             val existing = database.poiAddressDao().findPoiByPackage(poiName, poi.packageName)
             database.poiAddressDao().insertPoi(
@@ -170,7 +171,37 @@ class AppRepository private constructor(
                     sentMode = existing?.sentMode, // 즐겨찾기 명시 mode 보존
                     searchable = searchable,
                     created = existing?.created ?: Date(),
-                    lastCheckedAt = System.currentTimeMillis(),
+                    lastCheckedAt = now,
+                    lastUsedAt = now,
+                ),
+            )
+        }
+    }
+
+    /**
+     * Cache hit / cooldown skip 등 실제 API 호출이 발생하지 않은 사용 시점만 기록.
+     * lastUsedAt 만 갱신 — lastCheckedAt(cooldown anchor)는 보존.
+     */
+    suspend fun touchLastUsed(poi: Poi) {
+        val poiName = poi.poiName ?: return
+        database.withTransaction {
+            val existing = database.poiAddressDao().findPoiByPackage(poiName, poi.packageName) ?: return@withTransaction
+            database.poiAddressDao().insertPoi(
+                PoiAddressEntity(
+                    id = existing.id,
+                    poi = existing.poi,
+                    packageName = existing.packageName,
+                    roadAddress = existing.roadAddress,
+                    jibunAddress = existing.jibunAddress,
+                    latitude = existing.latitude,
+                    longitude = existing.longitude,
+                    registered = existing.registered,
+                    isDuplicate = existing.isDuplicate,
+                    sentMode = existing.sentMode,
+                    searchable = existing.searchable,
+                    created = existing.created,
+                    lastCheckedAt = existing.lastCheckedAt,
+                    lastUsedAt = System.currentTimeMillis(),
                 ),
             )
         }

--- a/app/src/main/kotlin/me/zipi/navitotesla/db/AppDatabase.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/db/AppDatabase.kt
@@ -18,6 +18,7 @@ import androidx.room.TypeConverters
         AutoMigration(from = 5, to = 6),
         AutoMigration(from = 6, to = 7),
         AutoMigration(from = 7, to = 8, spec = AppDatabaseAutoMigration7To8::class),
+        AutoMigration(from = 10, to = 11),
     ],
 )
 @TypeConverters(DateConverter::class)
@@ -43,7 +44,7 @@ abstract class AppDatabase : RoomDatabase() {
         private fun buildDatabase(appContext: Context): AppDatabase =
             Room
                 .databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
-                .addMigrations(MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11)
+                .addMigrations(MIGRATION_8_9, MIGRATION_9_10)
                 .build()
     }
 }

--- a/app/src/main/kotlin/me/zipi/navitotesla/db/AppDatabase.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/db/AppDatabase.kt
@@ -9,7 +9,7 @@ import androidx.room.TypeConverters
 
 @Database(
     entities = [PoiAddressEntity::class, ConditionEntity::class],
-    version = 10,
+    version = 11,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
@@ -43,7 +43,7 @@ abstract class AppDatabase : RoomDatabase() {
         private fun buildDatabase(appContext: Context): AppDatabase =
             Room
                 .databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
-                .addMigrations(MIGRATION_8_9, MIGRATION_9_10)
+                .addMigrations(MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11)
                 .build()
     }
 }

--- a/app/src/main/kotlin/me/zipi/navitotesla/db/AppDatabase.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/db/AppDatabase.kt
@@ -9,7 +9,7 @@ import androidx.room.TypeConverters
 
 @Database(
     entities = [PoiAddressEntity::class, ConditionEntity::class],
-    version = 11,
+    version = 12,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
@@ -19,6 +19,7 @@ import androidx.room.TypeConverters
         AutoMigration(from = 6, to = 7),
         AutoMigration(from = 7, to = 8, spec = AppDatabaseAutoMigration7To8::class),
         AutoMigration(from = 10, to = 11),
+        AutoMigration(from = 11, to = 12),
     ],
 )
 @TypeConverters(DateConverter::class)

--- a/app/src/main/kotlin/me/zipi/navitotesla/db/Migrations.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/db/Migrations.kt
@@ -18,10 +18,3 @@ val MIGRATION_9_10 =
             db.execSQL("UPDATE poi_address SET sentMode = NULL WHERE registered = 0")
         }
     }
-
-val MIGRATION_10_11 =
-    object : Migration(10, 11) {
-        override fun migrate(db: SupportSQLiteDatabase) {
-            db.execSQL("ALTER TABLE poi_address ADD COLUMN lastCheckedAt INTEGER")
-        }
-    }

--- a/app/src/main/kotlin/me/zipi/navitotesla/db/Migrations.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/db/Migrations.kt
@@ -18,3 +18,10 @@ val MIGRATION_9_10 =
             db.execSQL("UPDATE poi_address SET sentMode = NULL WHERE registered = 0")
         }
     }
+
+val MIGRATION_10_11 =
+    object : Migration(10, 11) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE poi_address ADD COLUMN lastCheckedAt INTEGER")
+        }
+    }

--- a/app/src/main/kotlin/me/zipi/navitotesla/db/PoiAddressDao.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/db/PoiAddressDao.kt
@@ -30,7 +30,12 @@ interface PoiAddressDao {
     @Query("SELECT * FROM poi_address WHERE created < :date AND (registered IS NULL OR registered = 0)")
     suspend fun findExpired(date: Long): List<PoiAddressEntity>
 
-    @Query("SELECT * FROM poi_address WHERE registered IS NULL OR registered = 0 ORDER BY created desc LIMIT :limit")
+    // 사용순 정렬: 마지막 share/classify 시점(lastCheckedAt) 기준 내림차순.
+    // legacy row(lastCheckedAt 이 null) 는 IFNULL 로 created 시점 사용.
+    @Query(
+        "SELECT * FROM poi_address WHERE registered IS NULL OR registered = 0 " +
+            "ORDER BY IFNULL(lastCheckedAt, created) DESC LIMIT :limit",
+    )
     suspend fun findRecentPoi(limit: Int): List<PoiAddressEntity>
 
     @Query("SELECT * FROM poi_address WHERE registered = 1 ORDER BY poi")

--- a/app/src/main/kotlin/me/zipi/navitotesla/db/PoiAddressDao.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/db/PoiAddressDao.kt
@@ -30,6 +30,16 @@ interface PoiAddressDao {
     @Query("SELECT * FROM poi_address WHERE created < :date AND (registered IS NULL OR registered = 0)")
     suspend fun findExpired(date: Long): List<PoiAddressEntity>
 
+    @Query("DELETE FROM poi_address WHERE created < :date AND (registered IS NULL OR registered = 0)")
+    suspend fun deleteExpired(date: Long): Int
+
+    @Query("UPDATE poi_address SET lastUsedAt = :now WHERE poi = :poi AND packageName = :packageName")
+    suspend fun updateLastUsedAt(
+        poi: String,
+        packageName: String,
+        now: Long,
+    ): Int
+
     @Query(
         "SELECT * FROM poi_address WHERE registered IS NULL OR registered = 0 " +
             "ORDER BY COALESCE(lastUsedAt, lastCheckedAt, created) DESC LIMIT :limit",

--- a/app/src/main/kotlin/me/zipi/navitotesla/db/PoiAddressDao.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/db/PoiAddressDao.kt
@@ -30,11 +30,11 @@ interface PoiAddressDao {
     @Query("SELECT * FROM poi_address WHERE created < :date AND (registered IS NULL OR registered = 0)")
     suspend fun findExpired(date: Long): List<PoiAddressEntity>
 
-    // 사용순 정렬: 마지막 share/classify 시점(lastCheckedAt) 기준 내림차순.
-    // legacy row(lastCheckedAt 이 null) 는 IFNULL 로 created 시점 사용.
+    // 사용순 정렬: 마지막 share 시점(lastUsedAt) 기준 내림차순.
+    // legacy row 대비 fallback: lastUsedAt → lastCheckedAt → created.
     @Query(
         "SELECT * FROM poi_address WHERE registered IS NULL OR registered = 0 " +
-            "ORDER BY IFNULL(lastCheckedAt, created) DESC LIMIT :limit",
+            "ORDER BY COALESCE(lastUsedAt, lastCheckedAt, created) DESC LIMIT :limit",
     )
     suspend fun findRecentPoi(limit: Int): List<PoiAddressEntity>
 

--- a/app/src/main/kotlin/me/zipi/navitotesla/db/PoiAddressDao.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/db/PoiAddressDao.kt
@@ -30,8 +30,6 @@ interface PoiAddressDao {
     @Query("SELECT * FROM poi_address WHERE created < :date AND (registered IS NULL OR registered = 0)")
     suspend fun findExpired(date: Long): List<PoiAddressEntity>
 
-    // 사용순 정렬: 마지막 share 시점(lastUsedAt) 기준 내림차순.
-    // legacy row 대비 fallback: lastUsedAt → lastCheckedAt → created.
     @Query(
         "SELECT * FROM poi_address WHERE registered IS NULL OR registered = 0 " +
             "ORDER BY COALESCE(lastUsedAt, lastCheckedAt, created) DESC LIMIT :limit",

--- a/app/src/main/kotlin/me/zipi/navitotesla/db/PoiAddressEntity.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/db/PoiAddressEntity.kt
@@ -26,8 +26,6 @@ class PoiAddressEntity(
     val sentMode: String? = null,
     val searchable: Boolean? = null,
     val created: Date? = null,
-    // 마지막 classify 시도 시각(epoch millis). searchable=null 로 끝난 경우에도 갱신되어
-    // 24h 쿨다운 동안 Places API/Firestore 재호출을 차단하는 anchor 로 쓰인다.
     val lastCheckedAt: Long? = null,
 ) {
     val isExpire: Boolean

--- a/app/src/main/kotlin/me/zipi/navitotesla/db/PoiAddressEntity.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/db/PoiAddressEntity.kt
@@ -26,6 +26,9 @@ class PoiAddressEntity(
     val sentMode: String? = null,
     val searchable: Boolean? = null,
     val created: Date? = null,
+    // 마지막 classify 시도 시각(epoch millis). searchable=null 로 끝난 경우에도 갱신되어
+    // 24h 쿨다운 동안 Places API/Firestore 재호출을 차단하는 anchor 로 쓰인다.
+    val lastCheckedAt: Long? = null,
 ) {
     val isExpire: Boolean
         get() {

--- a/app/src/main/kotlin/me/zipi/navitotesla/db/PoiAddressEntity.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/db/PoiAddressEntity.kt
@@ -5,6 +5,7 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import me.zipi.navitotesla.model.Poi
 import me.zipi.navitotesla.model.SendMode
+import me.zipi.navitotesla.service.place.Searchability
 import java.util.Date
 import kotlin.math.abs
 
@@ -36,6 +37,14 @@ class PoiAddressEntity(
             val expireDays = if (isDuplicate == true) DUPLICATE_EXPIRE_DAY else EXPIRE_DAY
             return ageInDays >= expireDays
         }
+
+    val searchability: Searchability
+        get() =
+            when (searchable) {
+                true -> Searchability.Searchable
+                false -> Searchability.NotSearchable
+                null -> Searchability.Unknown
+            }
 
     fun isRegistered(): Boolean = registered == true
 

--- a/app/src/main/kotlin/me/zipi/navitotesla/db/PoiAddressEntity.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/db/PoiAddressEntity.kt
@@ -28,6 +28,7 @@ class PoiAddressEntity(
     val searchable: Boolean? = null,
     val created: Date? = null,
     val lastCheckedAt: Long? = null,
+    val lastUsedAt: Long? = null,
 ) {
     val isExpire: Boolean
         get() {

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/NaviToTeslaService.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/NaviToTeslaService.kt
@@ -79,7 +79,6 @@ class NaviToTeslaService(
         val eventParam = Bundle()
         eventParam.putString("package", packageName)
         try {
-            // share 사이클 시작 시 만료 캐시 정리 — 이후 getPoi/classify 가 깔끔한 상태에서 동작.
             appRepository.clearExpiredPoi()
             val poi = getPoi(packageName, notificationTitle, notificationText)
             val lastAddress = PreferencesUtil.getString("lastAddress", "")

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/NaviToTeslaService.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/NaviToTeslaService.kt
@@ -79,6 +79,8 @@ class NaviToTeslaService(
         val eventParam = Bundle()
         eventParam.putString("package", packageName)
         try {
+            // share 사이클 시작 시 만료 캐시 정리 — 이후 getPoi/classify 가 깔끔한 상태에서 동작.
+            appRepository.clearExpiredPoi()
             val poi = getPoi(packageName, notificationTitle, notificationText)
             val lastAddress = PreferencesUtil.getString("lastAddress", "")
             if (lastAddress != poi.getRoadAddress()) {
@@ -96,7 +98,6 @@ class NaviToTeslaService(
                 )
                 AnalysisUtil.logEvent("previous_request_address", eventParam)
             }
-            appRepository.clearExpiredPoi()
         } catch (e: DuplicatePoiException) {
             AnalysisUtil.logEvent("duplicated_address", eventParam)
             AnalysisUtil.log("duplicate poi name: " + e.poiName)

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
@@ -30,6 +30,14 @@ object DestinationAddressResolver {
             return if (cached.searchable) Searchability.Searchable else Searchability.NotSearchable
         }
 
+        // Firestore 미스 후 Unknown 으로 끝났던 시도는 lastCheckedAt 로 기록된다.
+        // 쿨다운(default 24h) 동안은 동일 POI 에 대해 Firestore/Places API 호출을 둘 다 건너뛴다.
+        if (cached != null && cached.searchable == null && isWithinCooldown(cached.lastCheckedAt)) {
+            AnalysisUtil.debug("classify: cooldown active (lastCheckedAt=${cached.lastCheckedAt}), unknown")
+            AnalysisUtil.logEvent("place_check_cooldown_skip", eventParam)
+            return Searchability.Unknown
+        }
+
         val firebaseDisabledFlavor = !BuildConfig.DEBUG && BuildConfig.BUILD_MODE != "playstore"
         if (firebaseDisabledFlavor) {
             AnalysisUtil.debug("classify: firebase-disabled flavor, unknown")
@@ -78,12 +86,14 @@ object DestinationAddressResolver {
         val updateEnabled = RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_ENABLED)
         if (!updateEnabled) {
             AnalysisUtil.debug("classify: places update disabled by RC, unknown")
+            AppRepository.getInstance().markClassified(poi, null)
             return Searchability.Unknown
         }
 
         val ratio = RemoteConfigUtil.getLong(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_RATIO).coerceIn(0L, 100L).toInt()
         if (Random.nextInt(100) >= ratio) {
             AnalysisUtil.debug("classify: places update sampled out (ratio=$ratio), unknown")
+            AppRepository.getInstance().markClassified(poi, null)
             return Searchability.Unknown
         }
 
@@ -127,8 +137,18 @@ object DestinationAddressResolver {
             }
 
             null -> {
+                // Places API 예외(레이트 리밋 등). 다음 호출 때 24h 쿨다운으로 재시도를 막는다.
+                AppRepository.getInstance().markClassified(poi, null)
                 Searchability.Unknown
             }
         }
+    }
+
+    private fun isWithinCooldown(lastCheckedAt: Long?): Boolean {
+        if (lastCheckedAt == null) return false
+        val cooldownHours = RemoteConfigUtil.getLong(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_COOLDOWN_HOURS)
+        if (cooldownHours <= 0L) return false
+        val cooldownMs = cooldownHours * 60L * 60L * 1000L
+        return System.currentTimeMillis() - lastCheckedAt < cooldownMs
     }
 }

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
@@ -25,22 +25,22 @@ object DestinationAddressResolver {
 
         val dao = AppDatabase.getInstance().poiAddressDao()
         val cached = dao.findPoiByPackage(poiName, poi.packageName)?.takeUnless { it.isExpire }
+        if (cached != null) {
+            AppRepository.getInstance().touchLastUsed(poi)
+        }
         when (cached?.searchability) {
             Searchability.Searchable -> {
                 AnalysisUtil.debug("classify: local cache hit, searchable")
-                AppRepository.getInstance().touchLastUsed(poi)
                 return Searchability.Searchable
             }
             Searchability.NotSearchable -> {
                 AnalysisUtil.debug("classify: local cache hit, not_searchable")
-                AppRepository.getInstance().touchLastUsed(poi)
                 return Searchability.NotSearchable
             }
             Searchability.Unknown -> {
                 if (isWithinCooldown(cached.lastCheckedAt)) {
                     AnalysisUtil.debug("classify: cooldown active (lastCheckedAt=${cached.lastCheckedAt}), unknown")
                     AnalysisUtil.logEvent("place_check_cooldown_skip", eventParam)
-                    AppRepository.getInstance().touchLastUsed(poi)
                     return Searchability.Unknown
                 }
             }

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
@@ -24,28 +24,29 @@ object DestinationAddressResolver {
         AnalysisUtil.debug("classify start: poi='$poiName', pkg=${poi.packageName}")
 
         val dao = AppDatabase.getInstance().poiAddressDao()
-        val rawCached = dao.findPoiByPackage(poiName, poi.packageName)
-        // 쿨다운(default 24h)은 lastCheckedAt 기반. created 만료 여부와 무관 — expired row 라도
-        // 직전 check 가 24h 이내면 Firestore/Places API 둘 다 skip.
-        if (rawCached != null &&
-            rawCached.searchability == Searchability.Unknown &&
-            isWithinCooldown(rawCached.lastCheckedAt)
-        ) {
-            AnalysisUtil.debug("classify: cooldown active (lastCheckedAt=${rawCached.lastCheckedAt}), unknown")
-            AnalysisUtil.logEvent("place_check_cooldown_skip", eventParam)
-            return Searchability.Unknown
-        }
-        val cached = rawCached?.takeUnless { it.isExpire }
+        val cached = dao.findPoiByPackage(poiName, poi.packageName)?.takeUnless { it.isExpire }
         when (cached?.searchability) {
             Searchability.Searchable -> {
                 AnalysisUtil.debug("classify: local cache hit, searchable")
+                // 사용순 정렬을 위해 lastCheckedAt 갱신.
+                AppRepository.getInstance().markClassified(poi, Searchability.Searchable)
                 return Searchability.Searchable
             }
             Searchability.NotSearchable -> {
                 AnalysisUtil.debug("classify: local cache hit, not_searchable")
+                AppRepository.getInstance().markClassified(poi, Searchability.NotSearchable)
                 return Searchability.NotSearchable
             }
-            Searchability.Unknown, null -> Unit
+            // 쿨다운(default 24h) 동안은 동일 POI 에 대해 Firestore/Places API skip.
+            Searchability.Unknown -> {
+                if (isWithinCooldown(cached.lastCheckedAt)) {
+                    AnalysisUtil.debug("classify: cooldown active (lastCheckedAt=${cached.lastCheckedAt}), unknown")
+                    AnalysisUtil.logEvent("place_check_cooldown_skip", eventParam)
+                    AppRepository.getInstance().markClassified(poi, Searchability.Unknown)
+                    return Searchability.Unknown
+                }
+            }
+            null -> Unit
         }
 
         val firebaseDisabledFlavor = !BuildConfig.DEBUG && BuildConfig.BUILD_MODE != "playstore"

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
@@ -24,18 +24,25 @@ object DestinationAddressResolver {
         AnalysisUtil.debug("classify start: poi='$poiName', pkg=${poi.packageName}")
 
         val dao = AppDatabase.getInstance().poiAddressDao()
-        val cached = dao.findPoiByPackage(poiName, poi.packageName)
-        if (cached != null && !cached.isExpire && cached.searchable != null) {
-            AnalysisUtil.debug("classify: local cache hit, searchable=${cached.searchable}")
-            return if (cached.searchable) Searchability.Searchable else Searchability.NotSearchable
-        }
-
-        // Firestore 미스 후 Unknown 으로 끝났던 시도는 lastCheckedAt 로 기록된다.
-        // 쿨다운(default 24h) 동안은 동일 POI 에 대해 Firestore/Places API 호출을 둘 다 건너뛴다.
-        if (cached != null && cached.searchable == null && isWithinCooldown(cached.lastCheckedAt)) {
-            AnalysisUtil.debug("classify: cooldown active (lastCheckedAt=${cached.lastCheckedAt}), unknown")
-            AnalysisUtil.logEvent("place_check_cooldown_skip", eventParam)
-            return Searchability.Unknown
+        val cached = dao.findPoiByPackage(poiName, poi.packageName)?.takeUnless { it.isExpire }
+        when (cached?.searchability) {
+            Searchability.Searchable -> {
+                AnalysisUtil.debug("classify: local cache hit, searchable")
+                return Searchability.Searchable
+            }
+            Searchability.NotSearchable -> {
+                AnalysisUtil.debug("classify: local cache hit, not_searchable")
+                return Searchability.NotSearchable
+            }
+            // 쿨다운(default 24h) 동안은 동일 POI 에 대해 Firestore/Places API Skip
+            Searchability.Unknown -> {
+                if (isWithinCooldown(cached.lastCheckedAt)) {
+                    AnalysisUtil.debug("classify: cooldown active (lastCheckedAt=${cached.lastCheckedAt}), unknown")
+                    AnalysisUtil.logEvent("place_check_cooldown_skip", eventParam)
+                    return Searchability.Unknown
+                }
+            }
+            null -> Unit
         }
 
         val firebaseDisabledFlavor = !BuildConfig.DEBUG && BuildConfig.BUILD_MODE != "playstore"

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
@@ -28,7 +28,6 @@ object DestinationAddressResolver {
         when (cached?.searchability) {
             Searchability.Searchable -> {
                 AnalysisUtil.debug("classify: local cache hit, searchable")
-                // 사용순 정렬을 위해 lastUsedAt 만 갱신 (cooldown anchor 인 lastCheckedAt 은 보존).
                 AppRepository.getInstance().touchLastUsed(poi)
                 return Searchability.Searchable
             }
@@ -37,8 +36,6 @@ object DestinationAddressResolver {
                 AppRepository.getInstance().touchLastUsed(poi)
                 return Searchability.NotSearchable
             }
-            // 쿨다운(default 24h) 동안은 동일 POI 에 대해 Firestore/Places API skip.
-            // lastCheckedAt 은 갱신하지 않음 — 그래야 매일 안내해도 첫 anchor 로부터 24h 만 잠그고 그 후 재시도 가능.
             Searchability.Unknown -> {
                 if (isWithinCooldown(cached.lastCheckedAt)) {
                     AnalysisUtil.debug("classify: cooldown active (lastCheckedAt=${cached.lastCheckedAt}), unknown")
@@ -149,7 +146,6 @@ object DestinationAddressResolver {
             }
 
             null -> {
-                // Places API 예외(레이트 리밋 등). 다음 호출 때 쿨다운으로 재시도를 막는다.
                 AppRepository.getInstance().markClassified(poi, Searchability.Unknown)
                 Searchability.Unknown
             }
@@ -161,15 +157,15 @@ object DestinationAddressResolver {
         val cooldownHours =
             RemoteConfigUtil
                 .getLong(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_COOLDOWN_HOURS)
-                .coerceIn(0L, MAX_COOLDOWN_HOURS) // overflow 방지
+                .coerceIn(0L, MAX_COOLDOWN_HOURS)
         if (cooldownHours <= 0L) return false
         val cooldownMs = cooldownHours * 60L * 60L * 1000L
         val elapsedMs = System.currentTimeMillis() - lastCheckedAt
-        // 시계 역행(elapsedMs < 0) 시 쿨다운 만료로 처리. 시계 따라잡힐 때까지 무한 잠금 방지.
+        // 시계 역행(elapsedMs < 0) 시 쿨다운 만료로 처리.
         if (elapsedMs < 0L) return false
         return elapsedMs < cooldownMs
     }
 
-    // cooldownHours * 3_600_000L 이 Long overflow 되지 않는 최대값. (Long.MAX_VALUE / 3_600_000 ≈ 2.56e12)
+    // cooldownHours * 3_600_000L Long overflow 가드 상한.
     private const val MAX_COOLDOWN_HOURS = Long.MAX_VALUE / (60L * 60L * 1000L)
 }

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
@@ -24,7 +24,18 @@ object DestinationAddressResolver {
         AnalysisUtil.debug("classify start: poi='$poiName', pkg=${poi.packageName}")
 
         val dao = AppDatabase.getInstance().poiAddressDao()
-        val cached = dao.findPoiByPackage(poiName, poi.packageName)?.takeUnless { it.isExpire }
+        val rawCached = dao.findPoiByPackage(poiName, poi.packageName)
+        // 쿨다운(default 24h)은 lastCheckedAt 기반. created 만료 여부와 무관 — expired row 라도
+        // 직전 check 가 24h 이내면 Firestore/Places API 둘 다 skip.
+        if (rawCached != null &&
+            rawCached.searchability == Searchability.Unknown &&
+            isWithinCooldown(rawCached.lastCheckedAt)
+        ) {
+            AnalysisUtil.debug("classify: cooldown active (lastCheckedAt=${rawCached.lastCheckedAt}), unknown")
+            AnalysisUtil.logEvent("place_check_cooldown_skip", eventParam)
+            return Searchability.Unknown
+        }
+        val cached = rawCached?.takeUnless { it.isExpire }
         when (cached?.searchability) {
             Searchability.Searchable -> {
                 AnalysisUtil.debug("classify: local cache hit, searchable")
@@ -34,15 +45,7 @@ object DestinationAddressResolver {
                 AnalysisUtil.debug("classify: local cache hit, not_searchable")
                 return Searchability.NotSearchable
             }
-            // 쿨다운(default 24h) 동안은 동일 POI 에 대해 Firestore/Places API Skip
-            Searchability.Unknown -> {
-                if (isWithinCooldown(cached.lastCheckedAt)) {
-                    AnalysisUtil.debug("classify: cooldown active (lastCheckedAt=${cached.lastCheckedAt}), unknown")
-                    AnalysisUtil.logEvent("place_check_cooldown_skip", eventParam)
-                    return Searchability.Unknown
-                }
-            }
-            null -> Unit
+            Searchability.Unknown, null -> Unit
         }
 
         val firebaseDisabledFlavor = !BuildConfig.DEBUG && BuildConfig.BUILD_MODE != "playstore"
@@ -68,7 +71,7 @@ object DestinationAddressResolver {
                         putString("result", "searchable")
                     },
                 )
-                AppRepository.getInstance().markClassified(poi, true)
+                AppRepository.getInstance().markClassified(poi, Searchability.Searchable)
                 return Searchability.Searchable
             }
 
@@ -81,7 +84,7 @@ object DestinationAddressResolver {
                         putString("result", "not_searchable")
                     },
                 )
-                AppRepository.getInstance().markClassified(poi, false)
+                AppRepository.getInstance().markClassified(poi, Searchability.NotSearchable)
                 return Searchability.NotSearchable
             }
 
@@ -93,14 +96,14 @@ object DestinationAddressResolver {
         val updateEnabled = RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_ENABLED)
         if (!updateEnabled) {
             AnalysisUtil.debug("classify: places update disabled by RC, unknown")
-            AppRepository.getInstance().markClassified(poi, null)
+            AppRepository.getInstance().markClassified(poi, Searchability.Unknown)
             return Searchability.Unknown
         }
 
         val ratio = RemoteConfigUtil.getLong(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_RATIO).coerceIn(0L, 100L).toInt()
         if (Random.nextInt(100) >= ratio) {
             AnalysisUtil.debug("classify: places update sampled out (ratio=$ratio), unknown")
-            AppRepository.getInstance().markClassified(poi, null)
+            AppRepository.getInstance().markClassified(poi, Searchability.Unknown)
             return Searchability.Unknown
         }
 
@@ -126,7 +129,7 @@ object DestinationAddressResolver {
                     },
                 )
                 cacheClient.cache(roadAddress, searchable = true)
-                AppRepository.getInstance().markClassified(poi, true)
+                AppRepository.getInstance().markClassified(poi, Searchability.Searchable)
                 Searchability.Searchable
             }
 
@@ -139,13 +142,13 @@ object DestinationAddressResolver {
                     },
                 )
                 cacheClient.cache(roadAddress, searchable = false)
-                AppRepository.getInstance().markClassified(poi, false)
+                AppRepository.getInstance().markClassified(poi, Searchability.NotSearchable)
                 Searchability.NotSearchable
             }
 
             null -> {
-                // Places API 예외(레이트 리밋 등). 다음 호출 때 24h 쿨다운으로 재시도를 막는다.
-                AppRepository.getInstance().markClassified(poi, null)
+                // Places API 예외(레이트 리밋 등). 다음 호출 때 쿨다운으로 재시도를 막는다.
+                AppRepository.getInstance().markClassified(poi, Searchability.Unknown)
                 Searchability.Unknown
             }
         }
@@ -153,9 +156,18 @@ object DestinationAddressResolver {
 
     private fun isWithinCooldown(lastCheckedAt: Long?): Boolean {
         if (lastCheckedAt == null) return false
-        val cooldownHours = RemoteConfigUtil.getLong(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_COOLDOWN_HOURS)
+        val cooldownHours =
+            RemoteConfigUtil
+                .getLong(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_COOLDOWN_HOURS)
+                .coerceIn(0L, MAX_COOLDOWN_HOURS) // overflow 방지
         if (cooldownHours <= 0L) return false
         val cooldownMs = cooldownHours * 60L * 60L * 1000L
-        return System.currentTimeMillis() - lastCheckedAt < cooldownMs
+        val elapsedMs = System.currentTimeMillis() - lastCheckedAt
+        // 시계 역행(elapsedMs < 0) 시 쿨다운 만료로 처리. 시계 따라잡힐 때까지 무한 잠금 방지.
+        if (elapsedMs < 0L) return false
+        return elapsedMs < cooldownMs
     }
+
+    // cooldownHours * 3_600_000L 이 Long overflow 되지 않는 최대값. (Long.MAX_VALUE / 3_600_000 ≈ 2.56e12)
+    private const val MAX_COOLDOWN_HOURS = Long.MAX_VALUE / (60L * 60L * 1000L)
 }

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
@@ -28,21 +28,22 @@ object DestinationAddressResolver {
         when (cached?.searchability) {
             Searchability.Searchable -> {
                 AnalysisUtil.debug("classify: local cache hit, searchable")
-                // 사용순 정렬을 위해 lastCheckedAt 갱신.
-                AppRepository.getInstance().markClassified(poi, Searchability.Searchable)
+                // 사용순 정렬을 위해 lastUsedAt 만 갱신 (cooldown anchor 인 lastCheckedAt 은 보존).
+                AppRepository.getInstance().touchLastUsed(poi)
                 return Searchability.Searchable
             }
             Searchability.NotSearchable -> {
                 AnalysisUtil.debug("classify: local cache hit, not_searchable")
-                AppRepository.getInstance().markClassified(poi, Searchability.NotSearchable)
+                AppRepository.getInstance().touchLastUsed(poi)
                 return Searchability.NotSearchable
             }
             // 쿨다운(default 24h) 동안은 동일 POI 에 대해 Firestore/Places API skip.
+            // lastCheckedAt 은 갱신하지 않음 — 그래야 매일 안내해도 첫 anchor 로부터 24h 만 잠그고 그 후 재시도 가능.
             Searchability.Unknown -> {
                 if (isWithinCooldown(cached.lastCheckedAt)) {
                     AnalysisUtil.debug("classify: cooldown active (lastCheckedAt=${cached.lastCheckedAt}), unknown")
                     AnalysisUtil.logEvent("place_check_cooldown_skip", eventParam)
-                    AppRepository.getInstance().markClassified(poi, Searchability.Unknown)
+                    AppRepository.getInstance().touchLastUsed(poi)
                     return Searchability.Unknown
                 }
             }

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
@@ -33,10 +33,12 @@ object DestinationAddressResolver {
                 AnalysisUtil.debug("classify: local cache hit, searchable")
                 return Searchability.Searchable
             }
+
             Searchability.NotSearchable -> {
                 AnalysisUtil.debug("classify: local cache hit, not_searchable")
                 return Searchability.NotSearchable
             }
+
             Searchability.Unknown -> {
                 if (isWithinCooldown(cached.lastCheckedAt)) {
                     AnalysisUtil.debug("classify: cooldown active (lastCheckedAt=${cached.lastCheckedAt}), unknown")
@@ -44,7 +46,9 @@ object DestinationAddressResolver {
                     return Searchability.Unknown
                 }
             }
-            null -> Unit
+
+            null -> {
+            }
         }
 
         val firebaseDisabledFlavor = !BuildConfig.DEBUG && BuildConfig.BUILD_MODE != "playstore"

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/RemoteConfigUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/RemoteConfigUtil.kt
@@ -11,6 +11,7 @@ object RemoteConfigUtil {
     const val KEY_GOOGLE_PLACE_CHECK_UPDATE_RATIO = "googlePlaceCheckUpdateRatio"
     const val KEY_GOOGLE_PLACES_API_KEY = "googlePlacesApiKey"
     const val KEY_GOOGLE_PLACE_CHECK_TTL_DAYS = "googlePlaceCheckTtlDays"
+    const val KEY_GOOGLE_PLACE_CHECK_COOLDOWN_HOURS = "googlePlaceCheckCooldownHours"
     const val KEY_SEND_UNKNOWN_AS_NOT_SEARCHABLE = "sendUnknownAsNotSearchable"
     private const val FETCH_INTERVAL_SECONDS = 20 * 3600L
     private const val DEFAULT_VALUE = "default"

--- a/app/src/main/res/xml/remote_config_defaults.xml
+++ b/app/src/main/res/xml/remote_config_defaults.xml
@@ -41,6 +41,10 @@
         <value>30</value>
     </entry>
     <entry>
+        <key>googlePlaceCheckCooldownHours</key>
+        <value>24</value>
+    </entry>
+    <entry>
         <key>sendUnknownAsNotSearchable</key>
         <value>false</value>
     </entry>

--- a/app/src/test/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolverClassifyTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolverClassifyTest.kt
@@ -197,26 +197,6 @@ class DestinationAddressResolverClassifyTest {
         }
 
     @Test
-    fun `expired Unknown row still hits cooldown when lastCheckedAt within window`() =
-        runBlocking {
-            // created 가 expire 됐어도 lastCheckedAt 이 최근이면 쿨다운으로 Unknown 즉시 반환.
-            val createdLongAgo = java.util.Date(System.currentTimeMillis() - 35L * 24L * 60L * 60L * 1000L)
-            coEvery { dao.findPoiByPackage(any(), any()) } returns
-                entity(
-                    searchable = null,
-                    registered = false,
-                    lastCheckedAt = System.currentTimeMillis() - 60L * 60L * 1000L,
-                    created = createdLongAgo,
-                )
-            every {
-                RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED)
-            } returns true
-            fakeCache.lookupResult = PlaceAutocompleteCacheEntry.Searchable
-            assertSame(Searchability.Unknown, DestinationAddressResolver.classify(poi))
-            assertEquals(0, fakeCache.lookupCount)
-        }
-
-    @Test
     fun `cooldown disabled by RC=0 still falls through`() =
         runBlocking {
             // cooldownHours=0 → 쿨다운 기능 off. lastCheckedAt 이 최근이어도 firestore 진행.

--- a/app/src/test/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolverClassifyTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolverClassifyTest.kt
@@ -55,6 +55,8 @@ class DestinationAddressResolverClassifyTest {
         // RC 도 mock — Resolver 가 KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED 등을 직접 조회.
         mockkObject(RemoteConfigUtil)
         every { RemoteConfigUtil.getBoolean(any()) } returns false
+        every { RemoteConfigUtil.getLong(any()) } returns 0L
+        every { RemoteConfigUtil.getLong(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_COOLDOWN_HOURS) } returns 24L
 
         dao = mockk(relaxed = true)
         db = mockk(relaxed = true)
@@ -119,9 +121,106 @@ class DestinationAddressResolverClassifyTest {
             assertSame(Searchability.Searchable, DestinationAddressResolver.classify(poi))
         }
 
+    @Test
+    fun `cooldown active returns Unknown without firestore lookup`() =
+        runBlocking {
+            // lookup_enabled=true 인데도 lastCheckedAt 이 1h 전 → 쿨다운(24h) 안이라 firestore/places 둘 다 skip.
+            coEvery { dao.findPoiByPackage(any(), any()) } returns
+                entity(
+                    searchable = null,
+                    registered = false,
+                    lastCheckedAt = System.currentTimeMillis() - 60L * 60L * 1000L,
+                )
+            every {
+                RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED)
+            } returns true
+            fakeCache.lookupResult = PlaceAutocompleteCacheEntry.Searchable
+            assertSame(Searchability.Unknown, DestinationAddressResolver.classify(poi))
+            // firestore lookup 까지 도달하지 않았음을 확인.
+            assertEquals(0, fakeCache.lookupCount)
+        }
+
+    @Test
+    fun `cooldown expired falls through to firestore lookup`() =
+        runBlocking {
+            // lastCheckedAt 이 25h 전 → 24h 쿨다운 만료, firestore lookup 진행.
+            coEvery { dao.findPoiByPackage(any(), any()) } returns
+                entity(
+                    searchable = null,
+                    registered = false,
+                    lastCheckedAt = System.currentTimeMillis() - 25L * 60L * 60L * 1000L,
+                )
+            every {
+                RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED)
+            } returns true
+            fakeCache.lookupResult = PlaceAutocompleteCacheEntry.Searchable
+            assertSame(Searchability.Searchable, DestinationAddressResolver.classify(poi))
+            assertEquals(1, fakeCache.lookupCount)
+        }
+
+    @Test
+    fun `cooldown disabled by RC=0 still falls through`() =
+        runBlocking {
+            // cooldownHours=0 → 쿨다운 기능 off. lastCheckedAt 이 최근이어도 firestore 진행.
+            every { RemoteConfigUtil.getLong(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_COOLDOWN_HOURS) } returns 0L
+            coEvery { dao.findPoiByPackage(any(), any()) } returns
+                entity(
+                    searchable = null,
+                    registered = false,
+                    lastCheckedAt = System.currentTimeMillis() - 60L * 1000L,
+                )
+            every {
+                RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED)
+            } returns true
+            fakeCache.lookupResult = PlaceAutocompleteCacheEntry.Searchable
+            assertSame(Searchability.Searchable, DestinationAddressResolver.classify(poi))
+            assertEquals(1, fakeCache.lookupCount)
+        }
+
+    @Test
+    fun `sampled out path records cooldown via markClassified(null)`() =
+        runBlocking {
+            // lookup/update 둘 다 enabled, firestore miss, ratio=0 → 항상 sampled out.
+            coEvery { dao.findPoiByPackage(any(), any()) } returns null
+            every {
+                RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED)
+            } returns true
+            every {
+                RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_ENABLED)
+            } returns true
+            every {
+                RemoteConfigUtil.getLong(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_RATIO)
+            } returns 0L
+            fakeCache.lookupResult = null
+
+            assertSame(Searchability.Unknown, DestinationAddressResolver.classify(poi))
+            io.mockk.coVerify { repo.markClassified(poi, null) }
+        }
+
+    @Test
+    fun `places api exception path records cooldown via markClassified(null)`() =
+        runBlocking {
+            coEvery { dao.findPoiByPackage(any(), any()) } returns null
+            every {
+                RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED)
+            } returns true
+            every {
+                RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_ENABLED)
+            } returns true
+            every {
+                RemoteConfigUtil.getLong(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_RATIO)
+            } returns 100L
+            fakeCache.lookupResult = null
+            fakeMatcher.throwOnMatch = RuntimeException("rate limit")
+
+            assertSame(Searchability.Unknown, DestinationAddressResolver.classify(poi))
+            io.mockk.coVerify { repo.markClassified(poi, null) }
+        }
+
     private fun entity(
         searchable: Boolean?,
         registered: Boolean,
+        lastCheckedAt: Long? = null,
     ) = PoiAddressEntity(
         id = 1,
         poi = "서울특별시청",
@@ -135,13 +234,18 @@ class DestinationAddressResolverClassifyTest {
         sentMode = null,
         searchable = searchable,
         created = java.util.Date(),
+        lastCheckedAt = lastCheckedAt,
     )
 
     private class FakeCacheClient : PlaceAutocompleteCacheClient {
         var lookupResult: PlaceAutocompleteCacheEntry? = null
+        var lookupCount: Int = 0
         val cached = mutableListOf<Pair<String, Boolean>>()
 
-        override suspend fun lookup(address: String) = lookupResult
+        override suspend fun lookup(address: String): PlaceAutocompleteCacheEntry? {
+            lookupCount++
+            return lookupResult
+        }
 
         override suspend fun cache(
             address: String,
@@ -153,7 +257,11 @@ class DestinationAddressResolverClassifyTest {
 
     private class FakeMatcher : PlaceAutocompleteMatcher {
         var matchResult: Boolean = false
+        var throwOnMatch: Throwable? = null
 
-        override suspend fun isMatch(input: String) = matchResult
+        override suspend fun isMatch(input: String): Boolean {
+            throwOnMatch?.let { throw it }
+            return matchResult
+        }
     }
 }

--- a/app/src/test/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolverClassifyTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolverClassifyTest.kt
@@ -159,6 +159,64 @@ class DestinationAddressResolverClassifyTest {
         }
 
     @Test
+    fun `clock skew - negative elapsed treated as cooldown expired`() =
+        runBlocking {
+            // lastCheckedAt 이 미래(now + 10분) — 디바이스 시계 역행 시나리오.
+            coEvery { dao.findPoiByPackage(any(), any()) } returns
+                entity(
+                    searchable = null,
+                    registered = false,
+                    lastCheckedAt = System.currentTimeMillis() + 10L * 60L * 1000L,
+                )
+            every {
+                RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED)
+            } returns true
+            fakeCache.lookupResult = PlaceAutocompleteCacheEntry.Searchable
+            // 음수 elapsed → 쿨다운 무시하고 firestore 진행.
+            assertSame(Searchability.Searchable, DestinationAddressResolver.classify(poi))
+            assertEquals(1, fakeCache.lookupCount)
+        }
+
+    @Test
+    fun `cooldown overflow guard - huge cooldownHours coerced safely`() =
+        runBlocking {
+            // RC 값이 Long.MAX_VALUE 라 곱셈 overflow 위험 — coerceIn 으로 안전 범위 자르고 쿨다운 적용되어야.
+            every { RemoteConfigUtil.getLong(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_COOLDOWN_HOURS) } returns Long.MAX_VALUE
+            coEvery { dao.findPoiByPackage(any(), any()) } returns
+                entity(
+                    searchable = null,
+                    registered = false,
+                    lastCheckedAt = System.currentTimeMillis() - 60L * 60L * 1000L,
+                )
+            every {
+                RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED)
+            } returns true
+            fakeCache.lookupResult = PlaceAutocompleteCacheEntry.Searchable
+            assertSame(Searchability.Unknown, DestinationAddressResolver.classify(poi))
+            assertEquals(0, fakeCache.lookupCount)
+        }
+
+    @Test
+    fun `expired Unknown row still hits cooldown when lastCheckedAt within window`() =
+        runBlocking {
+            // created 가 expire 됐어도 lastCheckedAt 이 최근이면 쿨다운으로 Unknown 즉시 반환.
+            val createdLongAgo = java.util.Date(System.currentTimeMillis() - 35L * 24L * 60L * 60L * 1000L)
+            coEvery { dao.findPoiByPackage(any(), any()) } returns
+                entity(
+                    searchable = null,
+                    registered = false,
+                    lastCheckedAt = System.currentTimeMillis() - 60L * 60L * 1000L,
+                    created = createdLongAgo,
+                )
+            every {
+                RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED)
+            } returns true
+            fakeCache.lookupResult = PlaceAutocompleteCacheEntry.Searchable
+            assertSame(Searchability.Unknown, DestinationAddressResolver.classify(poi))
+            assertEquals(0, fakeCache.lookupCount)
+        }
+
+    @Test
     fun `cooldown disabled by RC=0 still falls through`() =
         runBlocking {
             // cooldownHours=0 → 쿨다운 기능 off. lastCheckedAt 이 최근이어도 firestore 진행.
@@ -194,7 +252,7 @@ class DestinationAddressResolverClassifyTest {
             fakeCache.lookupResult = null
 
             assertSame(Searchability.Unknown, DestinationAddressResolver.classify(poi))
-            io.mockk.coVerify { repo.markClassified(poi, null) }
+            io.mockk.coVerify { repo.markClassified(poi, Searchability.Unknown) }
         }
 
     @Test
@@ -214,13 +272,14 @@ class DestinationAddressResolverClassifyTest {
             fakeMatcher.throwOnMatch = RuntimeException("rate limit")
 
             assertSame(Searchability.Unknown, DestinationAddressResolver.classify(poi))
-            io.mockk.coVerify { repo.markClassified(poi, null) }
+            io.mockk.coVerify { repo.markClassified(poi, Searchability.Unknown) }
         }
 
     private fun entity(
         searchable: Boolean?,
         registered: Boolean,
         lastCheckedAt: Long? = null,
+        created: java.util.Date = java.util.Date(),
     ) = PoiAddressEntity(
         id = 1,
         poi = "서울특별시청",
@@ -233,7 +292,7 @@ class DestinationAddressResolverClassifyTest {
         isDuplicate = false,
         sentMode = null,
         searchable = searchable,
-        created = java.util.Date(),
+        created = created,
         lastCheckedAt = lastCheckedAt,
     )
 


### PR DESCRIPTION
## Summary
- Place API rate limit / sampling ratio 로 인해 분류 실패한 POI 에 대해 24h 쿨다운 추가 (`googlePlaceCheckCooldownHours` RC, default 24, 0 이면 off)
- `lastCheckedAt`(cooldown anchor) / `lastUsedAt`(사용 시점) 컬럼 분리 → 매일 안내해도 첫 anchor 로부터 정확히 24h 만 잠금
- `findRecentPoi` 정렬 기준을 `COALESCE(lastUsedAt, lastCheckedAt, created) DESC` 로 변경해 실제 사용순 반영
- DB 정리 로직 단순화: `clearExpiredPoi` 단일 DELETE + fire-and-forget, `touchLastUsed` 단일 UPDATE, EXPIRE_DAY 기준 통일(36일 buffer 제거)
- `markClassified` 시그니처를 `Boolean?` → `Searchability` enum 으로
- 쿨다운 가드: clock skew(음수 elapsed → 만료 처리) + Long overflow(상한 coerce)

## 동작 시나리오
- A 목적지 안내 시 Place API rate limit → 기본 안내로 fallback + `lastCheckedAt` 기록
- 24h 이내 동일 A 재안내 → Firestore/Places API skip, 즉시 Unknown 반환
- 24h 경과 후 다시 시도 → 정상 재확인

## 주요 변경
- `feat(place)`: 24h 쿨다운 도입 (Room v11, `lastCheckedAt`)
- `refactor(db)`: v11 AutoMigration 으로 전환
- `refactor(place)`: `Searchability` enum 일원화 + cache hit / 쿨다운 분기 정리
- `refactor(place)`: `lastUsedAt` 컬럼 분리 (Room v12) - 쿨다운 anchor 와 사용순 의미 분리
- `refactor(db)`: `touchLastUsed` / `clearExpiredPoi` 단일 쿼리화

## Test plan
- [x] 신규 단위 테스트 11 케이스 (`DestinationAddressResolverClassifyTest`) — local cache hit / cooldown active·expired·disabled / clock skew / overflow guard / sampled-out·API-exception cooldown anchor 기록
- [x] `./gradlew :app:testNostoreDebugUnitTest` 통과
- [x] `./gradlew :app:assembleNostoreDebug` 빌드 성공
- [x] Room AutoMigration 10→11→12 스키마 검증 (schema/11.json, 12.json 생성 확인)
- [ ] 실제 device 에서 share() 흐름 동작 확인 (notification → 24h cooldown 검증)