### PR TITLE
fix(favorite): 로그/캐싱 개선, 즐겨찾기 오류 수정

### DIFF
--- a/app/schemas/me.zipi.navitotesla.db.AppDatabase/13.json
+++ b/app/schemas/me.zipi.navitotesla.db.AppDatabase/13.json
@@ -1,0 +1,155 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 13,
+    "identityHash": "11d3052df6c21a4e104a1a609a49b8be",
+    "entities": [
+      {
+        "tableName": "poi_address",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `poi` TEXT NOT NULL, `packageName` TEXT, `roadAddress` TEXT, `jibunAddress` TEXT, `latitude` TEXT, `longitude` TEXT, `registered` INTEGER, `isDuplicate` INTEGER, `sentMode` TEXT, `searchable` INTEGER, `created` INTEGER, `lastCheckedAt` INTEGER, `lastUsedAt` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "poi",
+            "columnName": "poi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "roadAddress",
+            "columnName": "roadAddress",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "jibunAddress",
+            "columnName": "jibunAddress",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "registered",
+            "columnName": "registered",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isDuplicate",
+            "columnName": "isDuplicate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sentMode",
+            "columnName": "sentMode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "searchable",
+            "columnName": "searchable",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastCheckedAt",
+            "columnName": "lastCheckedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUsedAt",
+            "columnName": "lastUsedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_poi_address_poi_packageName",
+            "unique": true,
+            "columnNames": [
+              "poi",
+              "packageName"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_poi_address_poi_packageName` ON `${TABLE_NAME}` (`poi`, `packageName`)"
+          }
+        ]
+      },
+      {
+        "tableName": "condition",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `created` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_condition_type_name",
+            "unique": true,
+            "columnNames": [
+              "type",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_condition_type_name` ON `${TABLE_NAME}` (`type`, `name`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '11d3052df6c21a4e104a1a609a49b8be')"
+    ]
+  }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -92,6 +92,17 @@
             </intent-filter>
         </receiver>
 
+        <receiver android:name=".receiver.TeslaPackageReceiver"
+            android:exported="true"
+            android:enabled="true">
+            <intent-filter>
+                <action android:name="android.intent.action.PACKAGE_ADDED"/>
+                <action android:name="android.intent.action.PACKAGE_REMOVED"/>
+                <action android:name="android.intent.action.PACKAGE_REPLACED"/>
+                <data android:scheme="package"/>
+            </intent-filter>
+        </receiver>
+
     </application>
     <queries>
         <package android:name="com.teslamotors.tesla"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -98,8 +98,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.PACKAGE_ADDED"/>
                 <action android:name="android.intent.action.PACKAGE_REMOVED"/>
-                <action android:name="android.intent.action.PACKAGE_REPLACED"/>
-                <data android:scheme="package"/>
+                <data android:scheme="package" android:ssp="com.teslamotors.tesla"/>
             </intent-filter>
         </receiver>
 

--- a/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
@@ -89,28 +89,23 @@ class AppRepository private constructor(
             .create()
 
     /**
-     * 우선순위:
-     *   1) 같은 packageName 의 row (favorite 든 자동 저장 cache 든)
-     *   2) packageName="" 의 글로벌 favorite (사용자가 앱에서 직접 등록한 즐겨찾기)
-     * 다른 packageName 의 favorite/cache 는 매칭하지 않아 cross-navi hijack 을 방지.
+     * 우선순위 (1차 매칭 후 즉시 반환):
+     *   1) 같은 packageName 의 row (favorite or cache)
+     *   2) packageName 비어있는 글로벌 favorite (NULL 포함 — v1~v5 마이그레이션 row 보호)
+     *   3) 다른 packageName 의 favorite — 즐겨찾기는 navi 무관하게 같은 장소로 본다
      */
     suspend fun getPoiSync(
         poiName: String,
         packageName: String = "",
     ): PoiAddressEntity? {
-        val dao = database.poiAddressDao()
-        val byPackage =
-            if (packageName.isNotEmpty()) {
-                dao.findPoiByPackage(poiName, packageName)
-            } else {
-                dao.findPoiLatest(poiName)
-            }
-        if (byPackage != null) return byPackage
-        // cross-package fallback 은 packageName="" 의 글로벌 favorite 만 매칭.
+        val rows = database.poiAddressDao().findAllByPoi(poiName)
+        if (rows.isEmpty()) return null
+
         if (packageName.isNotEmpty()) {
-            return dao.findPoiByPackage(poiName, "")?.takeIf { it.isRegistered() }
+            rows.firstOrNull { it.packageName == packageName }?.let { return it }
         }
-        return null
+        rows.firstOrNull { it.isRegistered() && it.packageName.isNullOrEmpty() }?.let { return it }
+        return rows.firstOrNull { it.isRegistered() }
     }
 
     suspend fun savePoi(

--- a/app/src/main/kotlin/me/zipi/navitotesla/db/AppDatabase.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/db/AppDatabase.kt
@@ -9,7 +9,7 @@ import androidx.room.TypeConverters
 
 @Database(
     entities = [PoiAddressEntity::class, ConditionEntity::class],
-    version = 12,
+    version = 13,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
@@ -45,7 +45,7 @@ abstract class AppDatabase : RoomDatabase() {
         private fun buildDatabase(appContext: Context): AppDatabase =
             Room
                 .databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
-                .addMigrations(MIGRATION_8_9, MIGRATION_9_10)
+                .addMigrations(MIGRATION_8_9, MIGRATION_9_10, MIGRATION_12_13)
                 .build()
     }
 }

--- a/app/src/main/kotlin/me/zipi/navitotesla/db/Migrations.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/db/Migrations.kt
@@ -19,7 +19,6 @@ val MIGRATION_9_10 =
         }
     }
 
-// v1~v5 시절 등록된 favorite 가 v6 마이그레이션 시 packageName=NULL 로 채워져 매칭 누락되는 회귀(1.102) 정규화.
 val MIGRATION_12_13 =
     object : Migration(12, 13) {
         override fun migrate(db: SupportSQLiteDatabase) {

--- a/app/src/main/kotlin/me/zipi/navitotesla/db/Migrations.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/db/Migrations.kt
@@ -22,6 +22,11 @@ val MIGRATION_9_10 =
 val MIGRATION_12_13 =
     object : Migration(12, 13) {
         override fun migrate(db: SupportSQLiteDatabase) {
+            // 동일 poi 에 (NULL) 과 ('') row 공존 시 UPDATE unique index 충돌 방지 — NULL row 먼저 삭제.
+            db.execSQL(
+                "DELETE FROM poi_address WHERE packageName IS NULL " +
+                    "AND poi IN (SELECT poi FROM poi_address WHERE packageName = '')",
+            )
             db.execSQL("UPDATE poi_address SET packageName = '' WHERE packageName IS NULL")
         }
     }

--- a/app/src/main/kotlin/me/zipi/navitotesla/db/Migrations.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/db/Migrations.kt
@@ -18,3 +18,11 @@ val MIGRATION_9_10 =
             db.execSQL("UPDATE poi_address SET sentMode = NULL WHERE registered = 0")
         }
     }
+
+// v1~v5 시절 등록된 favorite 가 v6 마이그레이션 시 packageName=NULL 로 채워져 매칭 누락되는 회귀(1.102) 정규화.
+val MIGRATION_12_13 =
+    object : Migration(12, 13) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("UPDATE poi_address SET packageName = '' WHERE packageName IS NULL")
+        }
+    }

--- a/app/src/main/kotlin/me/zipi/navitotesla/db/PoiAddressDao.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/db/PoiAddressDao.kt
@@ -18,7 +18,7 @@ interface PoiAddressDao {
     @Query("SELECT * FROM poi_address WHERE poi = :poi LIMIT 1")
     suspend fun findPoi(poi: String): PoiAddressEntity?
 
-    @Query("SELECT * FROM poi_address WHERE poi = :poi")
+    @Query("SELECT * FROM poi_address WHERE poi = :poi ORDER BY lastUsedAt DESC, created DESC")
     suspend fun findAllByPoi(poi: String): List<PoiAddressEntity>
 
     @Query("SELECT * FROM poi_address WHERE poi = :poi AND packageName = :packageName")

--- a/app/src/main/kotlin/me/zipi/navitotesla/db/PoiAddressDao.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/db/PoiAddressDao.kt
@@ -18,6 +18,9 @@ interface PoiAddressDao {
     @Query("SELECT * FROM poi_address WHERE poi = :poi LIMIT 1")
     suspend fun findPoi(poi: String): PoiAddressEntity?
 
+    @Query("SELECT * FROM poi_address WHERE poi = :poi")
+    suspend fun findAllByPoi(poi: String): List<PoiAddressEntity>
+
     @Query("SELECT * FROM poi_address WHERE poi = :poi AND packageName = :packageName")
     suspend fun findPoiByPackage(
         poi: String,

--- a/app/src/main/kotlin/me/zipi/navitotesla/receiver/NotificationListener.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/receiver/NotificationListener.kt
@@ -26,7 +26,6 @@ class NotificationListener : NotificationListenerService() {
     @VisibleForTesting
     internal var serviceScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-    // 같은 title 의 반복 update 로그 폭주 방지 — title 변경 시에만 로깅.
     private val lastTitleByPackage = ConcurrentHashMap<String, String>()
 
     override fun onCreate() {
@@ -61,8 +60,7 @@ class NotificationListener : NotificationListenerService() {
                 val subText = extras.getString(Notification.EXTRA_SUB_TEXT) ?: ""
                 val bigText = extras.getCharSequence(Notification.EXTRA_BIG_TEXT)?.toString() ?: ""
 
-                val titleChanged = lastTitleByPackage.put(sbn.packageName, title) != title
-                if (titleChanged) {
+                if (lastTitleByPackage.put(sbn.packageName, title) != title) {
                     AnalysisUtil.log(
                         "onNotificationPosted ~ packageName: ${sbn.packageName} " +
                             "id: ${sbn.id} postTime: ${sbn.postTime} title: $title " +

--- a/app/src/main/kotlin/me/zipi/navitotesla/receiver/NotificationListener.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/receiver/NotificationListener.kt
@@ -18,12 +18,16 @@ import me.zipi.navitotesla.service.NaviToTeslaService
 import me.zipi.navitotesla.service.poifinder.PoiFinderFactory
 import me.zipi.navitotesla.util.AnalysisUtil
 import me.zipi.navitotesla.util.RemoteConfigUtil
+import java.util.concurrent.ConcurrentHashMap
 
 class NotificationListener : NotificationListenerService() {
     private lateinit var naviToTeslaService: NaviToTeslaService
 
     @VisibleForTesting
     internal var serviceScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    // 같은 title 의 반복 update 로그 폭주 방지 — title 변경 시에만 로깅.
+    private val lastTitleByPackage = ConcurrentHashMap<String, String>()
 
     override fun onCreate() {
         super.onCreate()
@@ -39,6 +43,7 @@ class NotificationListener : NotificationListenerService() {
         super.onNotificationRemoved(sbn)
         if (PoiFinderFactory.isNaviSupport(sbn.packageName)) {
             AnalysisUtil.log("onNotificationRemoved ~ packageName: ${sbn.packageName}")
+            lastTitleByPackage.remove(sbn.packageName)
             serviceScope.launch { naviToTeslaService.notificationClear() }
             val param = Bundle()
             param.putString("package", sbn.packageName)
@@ -56,11 +61,14 @@ class NotificationListener : NotificationListenerService() {
                 val subText = extras.getString(Notification.EXTRA_SUB_TEXT) ?: ""
                 val bigText = extras.getCharSequence(Notification.EXTRA_BIG_TEXT)?.toString() ?: ""
 
-                AnalysisUtil.log(
-                    "onNotificationPosted ~ packageName: ${sbn.packageName} " +
-                        "id: ${sbn.id} postTime: ${sbn.postTime} title: $title " +
-                        "text: $text subText: $subText bigText: $bigText",
-                )
+                val titleChanged = lastTitleByPackage.put(sbn.packageName, title) != title
+                if (titleChanged) {
+                    AnalysisUtil.log(
+                        "onNotificationPosted ~ packageName: ${sbn.packageName} " +
+                            "id: ${sbn.id} postTime: ${sbn.postTime} title: $title " +
+                            "text: $text subText: $subText bigText: $bigText",
+                    )
+                }
 
                 val bundle = Bundle()
                 bundle.putString(FirebaseAnalytics.Param.SCREEN_NAME, "NotificationListener")

--- a/app/src/main/kotlin/me/zipi/navitotesla/receiver/NotificationListener.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/receiver/NotificationListener.kt
@@ -26,7 +26,7 @@ class NotificationListener : NotificationListenerService() {
     @VisibleForTesting
     internal var serviceScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-    private val lastTitleByPackage = ConcurrentHashMap<String, String>()
+    private val lastTitleById = ConcurrentHashMap<Int, String>()
 
     override fun onCreate() {
         super.onCreate()
@@ -42,7 +42,7 @@ class NotificationListener : NotificationListenerService() {
         super.onNotificationRemoved(sbn)
         if (PoiFinderFactory.isNaviSupport(sbn.packageName)) {
             AnalysisUtil.log("onNotificationRemoved ~ packageName: ${sbn.packageName}")
-            lastTitleByPackage.remove(sbn.packageName)
+            lastTitleById.remove(sbn.id)
             serviceScope.launch { naviToTeslaService.notificationClear() }
             val param = Bundle()
             param.putString("package", sbn.packageName)
@@ -60,7 +60,7 @@ class NotificationListener : NotificationListenerService() {
                 val subText = extras.getString(Notification.EXTRA_SUB_TEXT) ?: ""
                 val bigText = extras.getCharSequence(Notification.EXTRA_BIG_TEXT)?.toString() ?: ""
 
-                if (lastTitleByPackage.put(sbn.packageName, title) != title) {
+                if (lastTitleById.put(sbn.id, title) != title) {
                     AnalysisUtil.log(
                         "onNotificationPosted ~ packageName: ${sbn.packageName} " +
                             "id: ${sbn.id} postTime: ${sbn.postTime} title: $title " +

--- a/app/src/main/kotlin/me/zipi/navitotesla/receiver/TeslaPackageReceiver.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/receiver/TeslaPackageReceiver.kt
@@ -1,0 +1,17 @@
+package me.zipi.navitotesla.receiver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import me.zipi.navitotesla.util.TeslaAppDetector
+
+class TeslaPackageReceiver : BroadcastReceiver() {
+    override fun onReceive(
+        context: Context,
+        intent: Intent,
+    ) {
+        val changedPackage = intent.data?.schemeSpecificPart ?: return
+        if (changedPackage != TeslaAppDetector.TESLA_PACKAGE) return
+        TeslaAppDetector.invalidate()
+    }
+}

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/NaviToTeslaService.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/NaviToTeslaService.kt
@@ -2,9 +2,6 @@ package me.zipi.navitotesla.service
 
 import android.content.Context
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
-import android.widget.Toast
 import com.google.firebase.perf.metrics.AddTrace
 import me.zipi.navitotesla.AppRepository
 import me.zipi.navitotesla.R
@@ -45,17 +42,10 @@ class NaviToTeslaService(
 
     fun isAddress(text: String): Boolean = ADDRESS_PATTERN.matcher(text).find()
 
-    private fun makeToast(text: String) {
-        try {
-            AnalysisUtil.log(text)
-            Handler(Looper.getMainLooper()).post {
-                Toast.makeText(context, text, Toast.LENGTH_LONG).show()
-            }
-        } catch (e: Exception) {
-            AnalysisUtil.recordException(e)
-            e.printStackTrace()
-        }
-    }
+    private fun makeToast(
+        text: String,
+        level: AnalysisUtil.ToastLevel = AnalysisUtil.ToastLevel.INFO,
+    ) = AnalysisUtil.makeToast(context = context, text = text, level = level)
 
     /**
      * 안내 종료
@@ -86,7 +76,7 @@ class NaviToTeslaService(
                 try {
                     share(poi)
                 } catch (_: ForbiddenException) {
-                    AnalysisUtil.log("force expire token and retry...")
+                    AnalysisUtil.warn("force expire token and retry...")
                     expireToken()
                     share(poi)
                 }
@@ -101,7 +91,10 @@ class NaviToTeslaService(
             AnalysisUtil.logEvent("duplicated_address", eventParam)
             AnalysisUtil.log("duplicate poi name: " + e.poiName)
             val duplicatedToast = {
-                makeToast(context.getString(R.string.sendDestinationFail) + "\n" + context.getString(R.string.duplicatedPoiName))
+                makeToast(
+                    text = context.getString(R.string.sendDestinationFail) + "\n" + context.getString(R.string.duplicatedPoiName),
+                    level = AnalysisUtil.ToastLevel.WARN,
+                )
             }
             val selectionEnabled = PreferencesUtil.getBoolean("duplicatePoiSelection", true)
             if (selectionEnabled && e.candidates.isNotEmpty()) {
@@ -111,7 +104,7 @@ class NaviToTeslaService(
                         duplicatedToast()
                     }
                 if (!shown) {
-                    AnalysisUtil.log("overlay permission denied for: " + e.poiName)
+                    AnalysisUtil.warn("overlay permission denied for: " + e.poiName)
                     duplicatedToast()
                 }
             } else {
@@ -120,16 +113,25 @@ class NaviToTeslaService(
         } catch (e: NotSupportedNaviException) {
             AnalysisUtil.logEvent("unsupported_navi", eventParam)
             AnalysisUtil.recordException(e)
-            makeToast(context.getString(R.string.sendDestinationFail) + "\n" + context.getString(R.string.unsupportedNavi))
+            makeToast(
+                text = context.getString(R.string.sendDestinationFail) + "\n" + context.getString(R.string.unsupportedNavi),
+                level = AnalysisUtil.ToastLevel.WARN,
+            )
         } catch (_: IgnorePoiException) {
             AnalysisUtil.logEvent("ignore_address", eventParam)
         } catch (e: ForbiddenException) {
-            makeToast(context.getString(R.string.sendDestinationFail) + "\n" + context.getString(R.string.authFail))
+            makeToast(
+                text = context.getString(R.string.sendDestinationFail) + "\n" + context.getString(R.string.authFail),
+                level = AnalysisUtil.ToastLevel.WARN,
+            )
             AnalysisUtil.logEvent("error_share", eventParam)
             AnalysisUtil.recordException(e)
         } catch (e: Exception) {
             AnalysisUtil.error("thread inside error", e)
-            makeToast(context.getString(R.string.sendDestinationFail) + "\n" + context.getString(R.string.apiError))
+            makeToast(
+                text = context.getString(R.string.sendDestinationFail) + "\n" + context.getString(R.string.apiError),
+                level = AnalysisUtil.ToastLevel.ERROR,
+            )
             AnalysisUtil.logEvent("error_share", eventParam)
             AnalysisUtil.recordException(e)
             AnalysisUtil.sendUnsentReports()
@@ -139,10 +141,11 @@ class NaviToTeslaService(
     @Throws(IOException::class, ForbiddenException::class)
     suspend fun share(poi: Poi) {
         if (poi.isAddressEmpty()) {
-            AnalysisUtil.log("share skipped: empty poi name=${poi.poiName}, pkg=${poi.packageName}")
+            AnalysisUtil.warn("share skipped: empty poi name=${poi.poiName}, pkg=${poi.packageName}")
             PreferencesUtil.put(key = "lastAddress", value = "")
             makeToast(
-                context.getString(R.string.sendDestinationFail) + "\n" + context.getString(R.string.addressNotFound),
+                text = context.getString(R.string.sendDestinationFail) + "\n" + context.getString(R.string.addressNotFound),
+                level = AnalysisUtil.ToastLevel.WARN,
             )
             return
         }
@@ -264,7 +267,7 @@ class NaviToTeslaService(
         if (refreshToken == null) {
             val token = PreferencesUtil.loadToken()
             if (token == null) {
-                makeToast(context.getString(R.string.notExistsToken))
+                makeToast(context.getString(R.string.notExistsToken), AnalysisUtil.ToastLevel.WARN)
                 return null
             } else if (!token.isExpire()) {
                 return token
@@ -289,11 +292,11 @@ class NaviToTeslaService(
             ResponseCloser.closeAll(newToken)
         } catch (e: Exception) {
             AnalysisUtil.warn("refresh token fail", e)
-            makeToast(context.getString(R.string.refreshTokenError))
+            makeToast(context.getString(R.string.refreshTokenError), AnalysisUtil.ToastLevel.WARN)
             AnalysisUtil.recordException(e)
         }
         if (token == null) {
-            AnalysisUtil.log("fail refresh access token. token is null")
+            AnalysisUtil.warn("fail refresh access token. token is null")
         }
         return token
     }
@@ -305,7 +308,7 @@ class NaviToTeslaService(
             actualToken = PreferencesUtil.loadToken()
         }
         if (actualToken?.refreshToken == null) {
-            makeToast(context.getString(R.string.requireToken))
+            makeToast(context.getString(R.string.requireToken), AnalysisUtil.ToastLevel.WARN)
             return emptyList()
         }
         val vehicles = mutableListOf<Vehicle>()
@@ -315,7 +318,7 @@ class NaviToTeslaService(
             }
             val response: Response<TeslaApiResponse.ListType<Map<String, Any>>> = appRepository.teslaApi.products()
             if (response.code() == 401) {
-                makeToast(context.getString(R.string.invalidToken))
+                makeToast(context.getString(R.string.invalidToken), AnalysisUtil.ToastLevel.WARN)
             } else if (response.isSuccessful) {
                 response
                     .body()
@@ -337,7 +340,7 @@ class NaviToTeslaService(
             AnalysisUtil.recordException(e)
         }
         if (vehicles.isEmpty()) {
-            makeToast(context.getString(R.string.noVehicle))
+            makeToast(text = context.getString(R.string.noVehicle), level = AnalysisUtil.ToastLevel.WARN)
         }
         return vehicles
     }

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/NaviToTeslaService.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/NaviToTeslaService.kt
@@ -229,7 +229,10 @@ class NaviToTeslaService(
         val poiAddressEntity = appRepository.getPoiSync(poiName, packageName)
         val poi: Poi
         if (poiAddressEntity != null && !poiAddressEntity.isExpire) {
-            poi = poiAddressEntity.toPoi().copy(packageName = packageName)
+            // favorite 의 원래 packageName 보존 — cross-package favorite 의 cache key 일관성 유지.
+            // 빈 packageName(글로벌 favorite) 인 경우만 share 출처 packageName 으로 보정.
+            val effectivePackage = poiAddressEntity.packageName?.takeIf { it.isNotEmpty() } ?: packageName
+            poi = poiAddressEntity.toPoi().copy(packageName = effectivePackage)
             AnalysisUtil.logEvent("address_parse_cache", eventParam)
         } else if (isAddress(poiName)) {
             poi =

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/share/TeslaShareByApi.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/share/TeslaShareByApi.kt
@@ -24,8 +24,8 @@ class TeslaShareByApi(
     override suspend fun share(payload: SendPayload) {
         if (BuildConfig.DEBUG) {
             AnalysisUtil.makeToast(
-                context,
-                "[DEBUG] 목적지 전송 By api Skip\n${payload.sendText}",
+                context = context,
+                text = "[DEBUG] 목적지 전송 By api Skip\n${payload.sendText}",
             )
             delay(500)
             return
@@ -38,20 +38,27 @@ class TeslaShareByApi(
 
         val result = response.body().takeIf { response.isSuccessful }
         if (result != null && result.error == null && (result.response?.result == true)) {
-            AnalysisUtil.makeToast(context, context.getString(R.string.sendDestinationSuccess) + "\n" + payload.displayText)
+            AnalysisUtil.makeToast(
+                context = context,
+                text = context.getString(R.string.sendDestinationSuccess) + "\n" + payload.displayText,
+            )
             AnalysisUtil.log("send_success")
             AnalysisUtil.logEvent("share_by_api_success", eventParam(packageName, payload))
         } else {
             AnalysisUtil.warn(response.toString())
-            AnalysisUtil.makeToast(context, context.getString(R.string.sendDestinationFail) + (result?.errorDescription ?: ""))
+            AnalysisUtil.makeToast(
+                context = context,
+                text = context.getString(R.string.sendDestinationFail) + (result?.errorDescription ?: ""),
+                level = AnalysisUtil.ToastLevel.WARN,
+            )
 
-            AnalysisUtil.log("send_fail")
+            AnalysisUtil.warn("send_fail")
             if (result?.errorDescription != null) {
-                AnalysisUtil.log("errorDescription: " + result.errorDescription)
+                AnalysisUtil.warn("errorDescription: " + result.errorDescription)
             }
             if (!response.isSuccessful) {
-                AnalysisUtil.log("Http response code: " + response.code())
-                response.errorBody()?.string()?.let { AnalysisUtil.log("Http error response: $it") }
+                AnalysisUtil.warn("Http response code: " + response.code())
+                response.errorBody()?.string()?.let { AnalysisUtil.warn("Http error response: $it") }
             }
             val exception: RuntimeException =
                 if (response.code() == 401) {

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/share/TeslaShareByApp.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/share/TeslaShareByApp.kt
@@ -24,8 +24,8 @@ class TeslaShareByApp(
 
         if (BuildConfig.DEBUG) {
             AnalysisUtil.makeToast(
-                context,
-                "[DEBUG] 목적지 전송 By App Skip\n${payload.sendText}",
+                context = context,
+                text = "[DEBUG] 목적지 전송 By App Skip\n${payload.sendText}",
             )
             return
         }
@@ -33,7 +33,7 @@ class TeslaShareByApp(
             context.startActivity(intent)
             AnalysisUtil.logEvent("share_by_app_success", eventParam(packageName, payload))
         } catch (_: ActivityNotFoundException) {
-            AnalysisUtil.log("Tesla app is not installed")
+            AnalysisUtil.warn("Tesla app is not installed")
             AnalysisUtil.logEvent("share_by_app_fail", eventParam(packageName, payload))
         }
     }

--- a/app/src/main/kotlin/me/zipi/navitotesla/ui/favorite/FavoriteDialogFragment.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/ui/favorite/FavoriteDialogFragment.kt
@@ -129,7 +129,11 @@ class FavoriteDialogFragment :
     private fun saveFavorite() {
         val poiName = binding.txtDest.text.toString()
         if (poiName.isEmpty()) {
-            AnalysisUtil.makeToast(context, getString(R.string.emptyPoiName))
+            AnalysisUtil.makeToast(
+                context = context,
+                text = getString(R.string.emptyPoiName),
+                level = AnalysisUtil.ToastLevel.WARN,
+            )
             return
         }
         val selected = favoriteDialogViewModel.selectedPoi.value
@@ -167,7 +171,11 @@ class FavoriteDialogFragment :
             val dao = AppDatabase.getInstance().poiAddressDao()
             val existing = dao.findRegisteredByPoi(entity.poi)
             if (existing != null) {
-                AnalysisUtil.makeToast(context, getString(R.string.duplicatedPoiName))
+                AnalysisUtil.makeToast(
+                    context = context,
+                    text = getString(R.string.duplicatedPoiName),
+                    level = AnalysisUtil.ToastLevel.WARN,
+                )
                 return@launch
             }
             dao.insertPoi(entity)

--- a/app/src/main/kotlin/me/zipi/navitotesla/ui/home/HomeFragment.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/ui/home/HomeFragment.kt
@@ -35,7 +35,6 @@ import com.gun0912.tedpermission.coroutine.TedPermission
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import me.zipi.navitotesla.BuildConfig
 import me.zipi.navitotesla.R
 import me.zipi.navitotesla.background.TokenWorker
 import me.zipi.navitotesla.databinding.FragmentHomeBinding
@@ -47,6 +46,7 @@ import me.zipi.navitotesla.service.NaviToTeslaService
 import me.zipi.navitotesla.util.AnalysisUtil
 import me.zipi.navitotesla.util.AppUpdaterUtil
 import me.zipi.navitotesla.util.PreferencesUtil
+import me.zipi.navitotesla.util.TeslaAppDetector
 import net.yslibrary.android.keyboardvisibilityevent.KeyboardVisibilityEvent.setEventListener
 import net.yslibrary.android.keyboardvisibilityevent.KeyboardVisibilityEventListener
 
@@ -476,22 +476,7 @@ class HomeFragment :
     }
 
     private val isTeslaAppInstalled: Boolean
-        get() {
-            if (context == null) {
-                return false
-            }
-            return if (BuildConfig.DEBUG) {
-                true
-            } else {
-                try {
-                    requireContext().packageManager.getPackageInfo("com.teslamotors.tesla", 0)
-                    true
-                } catch (e: PackageManager.NameNotFoundException) {
-                    AnalysisUtil.warn("package not found $e")
-                    false
-                }
-            }
-        }
+        get() = context?.let { TeslaAppDetector.isInstalled(it) } ?: false
 
     // share mode
     override fun onButtonChecked(

--- a/app/src/main/kotlin/me/zipi/navitotesla/ui/home/HomeFragment.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/ui/home/HomeFragment.kt
@@ -487,7 +487,7 @@ class HomeFragment :
                     requireContext().packageManager.getPackageInfo("com.teslamotors.tesla", 0)
                     true
                 } catch (e: PackageManager.NameNotFoundException) {
-                    AnalysisUtil.log("package not found $e")
+                    AnalysisUtil.warn("package not found $e")
                     false
                 }
             }

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/AnalysisUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/AnalysisUtil.kt
@@ -147,13 +147,19 @@ object AnalysisUtil {
             }
         }
 
+    enum class ToastLevel { INFO, WARN, ERROR }
+
     fun makeToast(
         context: Context?,
         text: String,
+        level: ToastLevel = ToastLevel.INFO,
     ) {
         try {
-            Log.i(LOG_TAG, text)
-            log(text)
+            when (level) {
+                ToastLevel.WARN -> warn(text)
+                ToastLevel.ERROR -> error(text)
+                ToastLevel.INFO -> log(text)
+            }
             CoroutineScope(Dispatchers.Main).launch {
                 if (context != null) {
                     Toast.makeText(context, text, Toast.LENGTH_LONG).show()

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/AnalysisUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/AnalysisUtil.kt
@@ -175,7 +175,14 @@ object AnalysisUtil {
         level: String,
         message: String,
     ) {
-        Log.i(LOG_TAG, message)
+        val priority =
+            when (level) {
+                "DEBUG" -> Log.DEBUG
+                "WARN" -> Log.WARN
+                "ERROR" -> Log.ERROR
+                else -> Log.INFO
+            }
+        Log.println(priority, LOG_TAG, message)
         val line = formatLine(level, message)
         logChannel.trySend(line)
     }

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/AppUpdaterUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/AppUpdaterUtil.kt
@@ -96,11 +96,11 @@ object AppUpdaterUtil {
                         )
 
                     if (response.code() == 403) {
-                        AnalysisUtil.log("github api rate limit exceed")
+                        AnalysisUtil.warn("github api rate limit exceed")
                     } else if (!response.isSuccessful || response.body() == null) {
-                        AnalysisUtil.log("github api call fail. Http code: " + response.code())
+                        AnalysisUtil.warn("github api call fail. Http code: " + response.code())
                         response.errorBody()?.string()?.let {
-                            AnalysisUtil.log(it)
+                            AnalysisUtil.warn(it)
                             AnalysisUtil.recordException(RuntimeException())
                         }
                     } else {
@@ -174,7 +174,7 @@ object AppUpdaterUtil {
                     clearDoNotShow()
                     return
                 } catch (e: ActivityNotFoundException) {
-                    AnalysisUtil.log("play store is installed, but launch error")
+                    AnalysisUtil.warn("play store is installed, but launch error")
                     AnalysisUtil.recordException(e)
                 }
             }

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/EnablerUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/EnablerUtil.kt
@@ -19,7 +19,7 @@ object EnablerUtil {
 
     fun addConnectedBluetooth(name: String?) {
         if (name == null) {
-            AnalysisUtil.log("add bluetooth name error. device name is null")
+            AnalysisUtil.warn("add bluetooth name error. device name is null")
             return
         }
         connectedBluetoothDevice.add(name.lowercase())
@@ -27,7 +27,7 @@ object EnablerUtil {
 
     fun removeConnectedBluetooth(name: String?) {
         if (name == null) {
-            AnalysisUtil.log("remove bluetooth name error. device name is null")
+            AnalysisUtil.warn("remove bluetooth name error. device name is null")
             return
         }
         connectedBluetoothDevice.remove(name.lowercase())
@@ -115,7 +115,7 @@ object EnablerUtil {
                     }
                 }
             } catch (Exception e) {
-                AnalysisUtil.log("error wifi condition check");
+                AnalysisUtil.warn("error wifi condition check");
                 AnalysisUtil.recordException(e);
                 return true;
             }

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/HttpRetryInterceptor.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/HttpRetryInterceptor.kt
@@ -39,7 +39,7 @@ class HttpRetryInterceptor(
                 response = chain.proceed(chain.request())
                 isSuccess = response.isSuccessful
                 if (!isSuccess) {
-                    AnalysisUtil.log("http status code : " + response.code)
+                    AnalysisUtil.warn("http status code : " + response.code)
                 }
             } catch (e: UnknownHostException) {
                 AnalysisUtil.info("Network unstable...#" + retry + " " + e.javaClass.name)
@@ -51,7 +51,7 @@ class HttpRetryInterceptor(
             if (isSuccess) {
                 break
             } else if (response != null && response.code >= 400 && response.code <= 405) {
-                AnalysisUtil.info("Http call 4xx error!: " + response.code)
+                AnalysisUtil.warn("Http call 4xx error!: " + response.code)
                 break
             } else if (retry >= maxRetryCount) {
                 if (response == null) {

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/TeslaAppDetector.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/TeslaAppDetector.kt
@@ -1,7 +1,6 @@
 package me.zipi.navitotesla.util
 
 import android.content.Context
-import me.zipi.navitotesla.BuildConfig
 
 object TeslaAppDetector {
     const val TESLA_PACKAGE = "com.teslamotors.tesla"
@@ -15,11 +14,9 @@ object TeslaAppDetector {
         cached = null
     }
 
-    private fun check(context: Context): Boolean {
-        if (BuildConfig.DEBUG) return true
-        return runCatching {
+    private fun check(context: Context): Boolean =
+        runCatching {
             context.packageManager.getPackageInfo(TESLA_PACKAGE, 0)
             true
         }.getOrDefault(false)
-    }
 }

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/TeslaAppDetector.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/TeslaAppDetector.kt
@@ -1,0 +1,25 @@
+package me.zipi.navitotesla.util
+
+import android.content.Context
+import me.zipi.navitotesla.BuildConfig
+
+object TeslaAppDetector {
+    const val TESLA_PACKAGE = "com.teslamotors.tesla"
+
+    @Volatile
+    private var cached: Boolean? = null
+
+    fun isInstalled(context: Context): Boolean = cached ?: check(context).also { cached = it }
+
+    fun invalidate() {
+        cached = null
+    }
+
+    private fun check(context: Context): Boolean {
+        if (BuildConfig.DEBUG) return true
+        return runCatching {
+            context.packageManager.getPackageInfo(TESLA_PACKAGE, 0)
+            true
+        }.getOrDefault(false)
+    }
+}


### PR DESCRIPTION
## Summary
- **favorite 매칭 회귀(1.102) 수정** — v1~v5 시절 등록된 favorite 가 v6 마이그레이션 시 `packageName=NULL` 로 채워져 1.102 의 fallback SQL `WHERE packageName=''` 매칭 누락 → "목적지를 찾을 수 없음" 발생
- **`getPoiSync` 3-tier 단일 쿼리** — 동일 packageName → 빈 packageName favorite → 다른 packageName favorite 우선순위
- **v13 마이그레이션** — `UPDATE packageName='' WHERE NULL` + UNIQUE 충돌 row 사전 정리
- **로깅 정비** — `AnalysisUtil.ToastLevel` enum, 오류성 로그 WARN/ERROR 분리, logcat priority 반영
- **Tesla 앱 설치 감지 캐싱** — `TeslaAppDetector` + `TeslaPackageReceiver` (ADDED/REMOVED, ssp 필터) — `package not found` WARN 폭주 해소
- **알림 로그 dedup** — `NotificationListener` 가 `sbn.id` 키로 같은 알림 update 중복 로깅 skip

## Test plan
- [x] `./gradlew :app:assembleNostoreDebug :app:testNostoreDebugUnitTest :app:ktlintCheck`
- [x] Room schema v13 자동 생성 확인 (12.json 과 동일 — data-only migration)
- [ ] 운영 디바이스에서 1.102 → 신규 빌드 업그레이드 후 기존 favorite 전송 동작 확인