### PR TITLE
fix(share): ShareWorker 중복 enqueue 방지

### DIFF
--- a/app/src/main/kotlin/me/zipi/navitotesla/background/ShareWorker.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/background/ShareWorker.kt
@@ -130,9 +130,11 @@ class ShareWorker(
                     .setConstraints(
                         Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build(),
                     ).build()
-            // 동일 navi 의 알림 update 가 짧게 두 번 발생하면 ShareWorker 가 race 로 중복 수행 → unique work 로 1개만.
+            // destination 별 unique key — 동일 알림 update 는 dedup, destination 변경 시엔 새 work enqueue.
+            val uniqueKey =
+                "share_${(packageName + (notificationTitle ?: "") + (notificationText ?: "")).hashCode()}"
             WorkManager.getInstance(context).enqueueUniqueWork(
-                "share_$packageName",
+                uniqueKey,
                 ExistingWorkPolicy.KEEP,
                 workRequest,
             )

--- a/app/src/main/kotlin/me/zipi/navitotesla/background/ShareWorker.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/background/ShareWorker.kt
@@ -11,12 +11,12 @@ import androidx.core.app.NotificationCompat
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
 import androidx.work.ForegroundInfo
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
-import androidx.work.WorkRequest
 import androidx.work.WorkerParameters
 import me.zipi.navitotesla.AppRepository
 import me.zipi.navitotesla.R
@@ -117,8 +117,8 @@ class ShareWorker(
             notificationText: String?,
         ) {
             AnalysisUtil.log("Register share worker")
-            val workRequest: WorkRequest =
-                OneTimeWorkRequestBuilder<ShareWorker>() // (ShareWorker::class.java)
+            val workRequest =
+                OneTimeWorkRequestBuilder<ShareWorker>()
                     .setInputData(
                         Data
                             .Builder()
@@ -130,7 +130,12 @@ class ShareWorker(
                     .setConstraints(
                         Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build(),
                     ).build()
-            WorkManager.getInstance(context).enqueue(workRequest)
+            // 동일 navi 의 알림 update 가 짧게 두 번 발생하면 ShareWorker 가 race 로 중복 수행 → unique work 로 1개만.
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                "share_$packageName",
+                ExistingWorkPolicy.KEEP,
+                workRequest,
+            )
         }
     }
 }

--- a/app/src/test/kotlin/me/zipi/navitotesla/background/ShareWorkerStartShareTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/background/ShareWorkerStartShareTest.kt
@@ -2,8 +2,9 @@ package me.zipi.navitotesla.background
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
-import androidx.work.WorkRequest
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import io.mockk.every
 import io.mockk.mockk
@@ -58,8 +59,14 @@ class ShareWorkerStartShareTest {
             notificationText = "내 위치 > 강남역",
         )
 
-        val captured = slot<WorkRequest>()
-        verify(exactly = 1) { workManager.enqueue(capture(captured)) }
+        val captured = slot<OneTimeWorkRequest>()
+        verify(exactly = 1) {
+            workManager.enqueueUniqueWork(
+                "share_com.skt.tmap.ku",
+                ExistingWorkPolicy.KEEP,
+                capture(captured),
+            )
+        }
 
         val spec = captured.captured.workSpec
         assertEquals(ShareWorker::class.java.name, spec.workerClassName)
@@ -77,8 +84,14 @@ class ShareWorkerStartShareTest {
             notificationText = "목적지 : 송파구청",
         )
 
-        val captured = slot<WorkRequest>()
-        verify(exactly = 1) { workManager.enqueue(capture(captured)) }
+        val captured = slot<OneTimeWorkRequest>()
+        verify(exactly = 1) {
+            workManager.enqueueUniqueWork(
+                "share_com.locnall.KimGiSa",
+                ExistingWorkPolicy.KEEP,
+                capture(captured),
+            )
+        }
 
         val spec = captured.captured.workSpec
         assertEquals(ShareWorker::class.java.name, spec.workerClassName)

--- a/app/src/test/kotlin/me/zipi/navitotesla/background/ShareWorkerStartShareTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/background/ShareWorkerStartShareTest.kt
@@ -60,9 +60,10 @@ class ShareWorkerStartShareTest {
         )
 
         val captured = slot<OneTimeWorkRequest>()
+        val expectedKey = "share_${("com.skt.tmap.ku" + "경로주행" + "내 위치 > 강남역").hashCode()}"
         verify(exactly = 1) {
             workManager.enqueueUniqueWork(
-                "share_com.skt.tmap.ku",
+                expectedKey,
                 ExistingWorkPolicy.KEEP,
                 capture(captured),
             )
@@ -85,9 +86,10 @@ class ShareWorkerStartShareTest {
         )
 
         val captured = slot<OneTimeWorkRequest>()
+        val expectedKey = "share_${("com.locnall.KimGiSa" + "길안내 주행 중" + "목적지 : 송파구청").hashCode()}"
         verify(exactly = 1) {
             workManager.enqueueUniqueWork(
-                "share_com.locnall.KimGiSa",
+                expectedKey,
                 ExistingWorkPolicy.KEEP,
                 capture(captured),
             )


### PR DESCRIPTION
## Summary
- navi 앱이 동일 알림을 짧게 두 번 update → `onNotificationPosted` 두 번 호출 → `ShareWorker` 두 개 enqueue → race 로 `lastAddress` dedup 실패 → **Tesla API 동일 destination 으로 2번 호출**
- 해결: `WorkManager.enqueueUniqueWork("share_$packageName", KEEP, ...)` — packageName 별 1개만 진행, 진행 중에 새 enqueue 는 무시

## Test plan
- [x] `./gradlew :app:assembleNostoreDebug :app:testNostoreDebugUnitTest :app:ktlintCheck`
- [x] 기존 `ShareWorkerStartShareTest` 가 `enqueueUniqueWork` 검증으로 변경됨