### PR TITLE
feat(place): 캐시율 향상 위해 형제 주소 사전 입력

### DIFF
--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/AddressCanonicalizer.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/AddressCanonicalizer.kt
@@ -1,0 +1,15 @@
+package me.zipi.navitotesla.service.place
+
+object AddressCanonicalizer {
+    private val WHITESPACE = Regex("\\s+")
+
+    /** 맨 앞 "대한민국" 토큰 제거 + 내부 연속공백 1칸 + trim. 읽기/쓰기 공통 키 정규화. */
+    fun canonicalize(address: String): String {
+        val collapsed = address.trim().replace(WHITESPACE, " ")
+        return when {
+            collapsed == "대한민국" -> ""
+            collapsed.startsWith("대한민국 ") -> collapsed.removePrefix("대한민국 ")
+            else -> collapsed
+        }
+    }
+}

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/AddressPrefixBuilder.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/AddressPrefixBuilder.kt
@@ -1,0 +1,24 @@
+package me.zipi.navitotesla.service.place
+
+object AddressPrefixBuilder {
+    data class Prefix(
+        val prefix: String,
+        val isTruncated: Boolean,
+    )
+
+    /**
+     * 1차 prefix 생성. 마지막 글자가 숫자이고 끝 토큰의 숫자가 2개 이상이면 마지막 1글자를 자른다.
+     * 번지가 1자리거나 말미가 비숫자면 절단하지 않는다(1차==2차).
+     */
+    fun build(address: String): Prefix {
+        val t = address.trim()
+        if (t.isEmpty()) return Prefix("", false)
+        val lastToken = t.substringAfterLast(' ')
+        val digitCount = lastToken.count { it.isDigit() }
+        return if (t.last().isDigit() && digitCount >= 2) {
+            Prefix(t.dropLast(1), true)
+        } else {
+            Prefix(t, false)
+        }
+    }
+}

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
@@ -139,10 +139,11 @@ object DestinationAddressResolver {
         }
         if (prefixEnabled) cacheClient.cacheSiblings(first.predictions)
 
-        val resolved: Boolean =
+        // searchable 판정을 낸 질의 결과(matchedPlaceId 추출용). null 이면 NotSearchable.
+        val resolved: AutocompleteResult? =
             when {
-                first.matched -> true
-                first.predictions.size < MAX_PREDICTIONS -> false
+                first.matched -> first
+                first.predictions.size < MAX_PREDICTIONS -> null
                 prefixSpec.isTruncated -> {
                     val second =
                         try {
@@ -159,12 +160,12 @@ object DestinationAddressResolver {
                         return Searchability.Unknown
                     }
                     if (prefixEnabled) cacheClient.cacheSiblings(second.predictions)
-                    second.matched
+                    second.takeIf { it.matched }
                 }
-                else -> false
+                else -> null
             }
 
-        return if (resolved) {
+        return if (resolved != null) {
             AnalysisUtil.logEvent(
                 "firestore_set",
                 Bundle().apply {
@@ -172,7 +173,7 @@ object DestinationAddressResolver {
                     putString("result", "searchable")
                 },
             )
-            cacheClient.cache(roadAddress, searchable = true)
+            cacheClient.cache(roadAddress, searchable = true, placesId = resolved.matchedPlaceId)
             AppRepository.getInstance().markClassified(poi, Searchability.Searchable)
             Searchability.Searchable
         } else {

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
@@ -115,51 +115,81 @@ object DestinationAddressResolver {
             return Searchability.Unknown
         }
 
-        val matched =
+        val prefixEnabled = RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_PREFIX_ENABLED)
+        val prefixSpec =
+            if (prefixEnabled) {
+                AddressPrefixBuilder.build(roadAddress)
+            } else {
+                AddressPrefixBuilder.Prefix(roadAddress, isTruncated = false)
+            }
+
+        val first =
             try {
                 AnalysisUtil.logEvent("places_api_call", eventParam)
-                matcher.isMatch(roadAddress)
+                matcher.query(prefixSpec.prefix)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 AnalysisUtil.recordException(e)
                 null
             }
-        AnalysisUtil.debug("classify: places_api match=$matched")
+        if (first == null) {
+            AppRepository.getInstance().markClassified(poi, Searchability.Unknown)
+            return Searchability.Unknown
+        }
+        if (prefixEnabled) cacheClient.cacheSiblings(first.predictions)
 
-        return when (matched) {
-            true -> {
-                AnalysisUtil.logEvent(
-                    "firestore_set",
-                    Bundle().apply {
-                        putString("package", poi.packageName)
-                        putString("result", "searchable")
-                    },
-                )
-                cacheClient.cache(roadAddress, searchable = true)
-                AppRepository.getInstance().markClassified(poi, Searchability.Searchable)
-                Searchability.Searchable
+        val resolved: Boolean =
+            when {
+                first.matched -> true
+                first.predictions.size < MAX_PREDICTIONS -> false
+                prefixSpec.isTruncated -> {
+                    val second =
+                        try {
+                            AnalysisUtil.logEvent("places_api_call", eventParam)
+                            matcher.query(roadAddress)
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            AnalysisUtil.recordException(e)
+                            null
+                        }
+                    if (second == null) {
+                        AppRepository.getInstance().markClassified(poi, Searchability.Unknown)
+                        return Searchability.Unknown
+                    }
+                    if (prefixEnabled) cacheClient.cacheSiblings(second.predictions)
+                    second.matched
+                }
+                else -> false
             }
 
-            false -> {
-                AnalysisUtil.logEvent(
-                    "firestore_set",
-                    Bundle().apply {
-                        putString("package", poi.packageName)
-                        putString("result", "not_searchable")
-                    },
-                )
-                cacheClient.cache(roadAddress, searchable = false)
-                AppRepository.getInstance().markClassified(poi, Searchability.NotSearchable)
-                Searchability.NotSearchable
-            }
-
-            null -> {
-                AppRepository.getInstance().markClassified(poi, Searchability.Unknown)
-                Searchability.Unknown
-            }
+        return if (resolved) {
+            AnalysisUtil.logEvent(
+                "firestore_set",
+                Bundle().apply {
+                    putString("package", poi.packageName)
+                    putString("result", "searchable")
+                },
+            )
+            cacheClient.cache(roadAddress, searchable = true)
+            AppRepository.getInstance().markClassified(poi, Searchability.Searchable)
+            Searchability.Searchable
+        } else {
+            AnalysisUtil.logEvent(
+                "firestore_set",
+                Bundle().apply {
+                    putString("package", poi.packageName)
+                    putString("result", "not_searchable")
+                },
+            )
+            cacheClient.cache(roadAddress, searchable = false)
+            AppRepository.getInstance().markClassified(poi, Searchability.NotSearchable)
+            Searchability.NotSearchable
         }
     }
+
+    private const val MAX_PREDICTIONS = 5
 
     private fun isWithinCooldown(lastCheckedAt: Long?): Boolean {
         if (lastCheckedAt == null) return false

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
@@ -139,7 +139,7 @@ object DestinationAddressResolver {
         }
         if (prefixEnabled) cacheClient.cacheSiblings(first.predictions)
 
-        // searchable 판정을 낸 질의 결과(matchedPlaceId 추출용). null 이면 NotSearchable.
+        // matchedPlaceId 추출 때문에 boolean 대신 질의 결과를 들고 간다.
         val resolved: AutocompleteResult? =
             when {
                 first.matched -> first

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
@@ -121,15 +121,17 @@ object DestinationAddressResolver {
                 AddressPrefixBuilder.Prefix(roadAddress, isTruncated = false)
             }
 
-        val first = queryAndCacheSiblings(prefixSpec.prefix, prefixEnabled, eventParam) ?: return markUnknown(poi)
+        AnalysisUtil.debug("classify: road='$roadAddress' prefix='${prefixSpec.prefix}' truncated=${prefixSpec.isTruncated} prefixEnabled=$prefixEnabled")
+
+        val first = queryAndCacheSiblings(prefixSpec.prefix, roadAddress, prefixEnabled, eventParam) ?: return markUnknown(poi)
 
         // matchedPlaceId 추출 때문에 boolean 대신 질의 결과를 들고 간다. null 이면 NotSearchable.
+        // prefix 에서 못 찾고 prefix≠full(절단) 이면, prefix 자동완성 누락 가능성이 있어 full 로 한 번 더 확인한다.
         val resolved: AutocompleteResult? =
             when {
                 first.matched -> first
-                first.predictions.size < MAX_PREDICTIONS -> null
                 prefixSpec.isTruncated ->
-                    (queryAndCacheSiblings(roadAddress, prefixEnabled, eventParam) ?: return markUnknown(poi))
+                    (queryAndCacheSiblings(roadAddress, roadAddress, prefixEnabled, eventParam) ?: return markUnknown(poi))
                         .takeIf { it.matched }
                 else -> null
             }
@@ -144,6 +146,7 @@ object DestinationAddressResolver {
         )
         cacheClient.cache(roadAddress, searchable = searchable, placesId = resolved?.matchedPlaceId)
         val result = if (searchable) Searchability.Searchable else Searchability.NotSearchable
+        AnalysisUtil.debug("classify: verdict=$result road='$roadAddress' placesId=${resolved?.matchedPlaceId}")
         AppRepository.getInstance().markClassified(poi, result)
         return result
     }
@@ -153,23 +156,31 @@ object DestinationAddressResolver {
         return Searchability.Unknown
     }
 
-    // places API 질의 + (prefix 활성 시) 형제 캐싱. API 오류 시 null → 호출부에서 Unknown 처리.
+    // queryInput 으로 자동완성 조회(매칭은 target 기준) + (prefix 활성 시) 형제 캐싱. API 오류 시 null → Unknown.
     private suspend fun queryAndCacheSiblings(
-        input: String,
+        queryInput: String,
+        target: String,
         prefixEnabled: Boolean,
         eventParam: Bundle,
     ): AutocompleteResult? {
         val result =
             try {
                 AnalysisUtil.logEvent("places_api_call", eventParam)
-                matcher.query(input)
+                matcher.query(queryInput, target)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 AnalysisUtil.recordException(e)
                 return null
             }
-        if (prefixEnabled) cacheClient.cacheSiblings(result.predictions)
+        AnalysisUtil.debug(
+            "places query='$queryInput' target='$target' matched=${result.matched} matchedPlaceId=${result.matchedPlaceId} " +
+                "predictions=${result.predictions.map { "${it.fullText}|${it.placeId}" }}",
+        )
+        if (prefixEnabled) {
+            cacheClient.cacheSiblings(result.predictions)
+            AnalysisUtil.debug("cacheSiblings: ${result.predictions.size}건 기록")
+        }
         return result
     }
 

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
@@ -104,15 +104,13 @@ object DestinationAddressResolver {
         val updateEnabled = RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_ENABLED)
         if (!updateEnabled) {
             AnalysisUtil.debug("classify: places update disabled by RC, unknown")
-            AppRepository.getInstance().markClassified(poi, Searchability.Unknown)
-            return Searchability.Unknown
+            return markUnknown(poi)
         }
 
         val ratio = RemoteConfigUtil.getLong(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_RATIO).coerceIn(0L, 100L).toInt()
         if (Random.nextInt(100) >= ratio) {
             AnalysisUtil.debug("classify: places update sampled out (ratio=$ratio), unknown")
-            AppRepository.getInstance().markClassified(poi, Searchability.Unknown)
-            return Searchability.Unknown
+            return markUnknown(poi)
         }
 
         val prefixEnabled = RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_PREFIX_ENABLED)
@@ -123,74 +121,57 @@ object DestinationAddressResolver {
                 AddressPrefixBuilder.Prefix(roadAddress, isTruncated = false)
             }
 
-        val first =
-            try {
-                AnalysisUtil.logEvent("places_api_call", eventParam)
-                matcher.query(prefixSpec.prefix)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                AnalysisUtil.recordException(e)
-                null
-            }
-        if (first == null) {
-            AppRepository.getInstance().markClassified(poi, Searchability.Unknown)
-            return Searchability.Unknown
-        }
-        if (prefixEnabled) cacheClient.cacheSiblings(first.predictions)
+        val first = queryAndCacheSiblings(prefixSpec.prefix, prefixEnabled, eventParam) ?: return markUnknown(poi)
 
-        // matchedPlaceId 추출 때문에 boolean 대신 질의 결과를 들고 간다.
+        // matchedPlaceId 추출 때문에 boolean 대신 질의 결과를 들고 간다. null 이면 NotSearchable.
         val resolved: AutocompleteResult? =
             when {
                 first.matched -> first
                 first.predictions.size < MAX_PREDICTIONS -> null
-                prefixSpec.isTruncated -> {
-                    val second =
-                        try {
-                            AnalysisUtil.logEvent("places_api_call", eventParam)
-                            matcher.query(roadAddress)
-                        } catch (e: CancellationException) {
-                            throw e
-                        } catch (e: Exception) {
-                            AnalysisUtil.recordException(e)
-                            null
-                        }
-                    if (second == null) {
-                        AppRepository.getInstance().markClassified(poi, Searchability.Unknown)
-                        return Searchability.Unknown
-                    }
-                    if (prefixEnabled) cacheClient.cacheSiblings(second.predictions)
-                    second.takeIf { it.matched }
-                }
+                prefixSpec.isTruncated ->
+                    (queryAndCacheSiblings(roadAddress, prefixEnabled, eventParam) ?: return markUnknown(poi))
+                        .takeIf { it.matched }
                 else -> null
             }
 
-        return if (resolved != null) {
-            AnalysisUtil.logEvent(
-                "firestore_set",
-                Bundle().apply {
-                    putString("package", poi.packageName)
-                    putString("result", "searchable")
-                },
-            )
-            cacheClient.cache(roadAddress, searchable = true, placesId = resolved.matchedPlaceId)
-            AppRepository.getInstance().markClassified(poi, Searchability.Searchable)
-            Searchability.Searchable
-        } else {
-            AnalysisUtil.logEvent(
-                "firestore_set",
-                Bundle().apply {
-                    putString("package", poi.packageName)
-                    putString("result", "not_searchable")
-                },
-            )
-            cacheClient.cache(roadAddress, searchable = false)
-            AppRepository.getInstance().markClassified(poi, Searchability.NotSearchable)
-            Searchability.NotSearchable
-        }
+        val searchable = resolved != null
+        AnalysisUtil.logEvent(
+            "firestore_set",
+            Bundle().apply {
+                putString("package", poi.packageName)
+                putString("result", if (searchable) "searchable" else "not_searchable")
+            },
+        )
+        cacheClient.cache(roadAddress, searchable = searchable, placesId = resolved?.matchedPlaceId)
+        val result = if (searchable) Searchability.Searchable else Searchability.NotSearchable
+        AppRepository.getInstance().markClassified(poi, result)
+        return result
     }
 
-    private const val MAX_PREDICTIONS = 5
+    private suspend fun markUnknown(poi: Poi): Searchability {
+        AppRepository.getInstance().markClassified(poi, Searchability.Unknown)
+        return Searchability.Unknown
+    }
+
+    // places API 질의 + (prefix 활성 시) 형제 캐싱. API 오류 시 null → 호출부에서 Unknown 처리.
+    private suspend fun queryAndCacheSiblings(
+        input: String,
+        prefixEnabled: Boolean,
+        eventParam: Bundle,
+    ): AutocompleteResult? {
+        val result =
+            try {
+                AnalysisUtil.logEvent("places_api_call", eventParam)
+                matcher.query(input)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                AnalysisUtil.recordException(e)
+                return null
+            }
+        if (prefixEnabled) cacheClient.cacheSiblings(result.predictions)
+        return result
+    }
 
     private fun isWithinCooldown(lastCheckedAt: Long?): Boolean {
         if (lastCheckedAt == null) return false

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
@@ -121,8 +121,6 @@ object DestinationAddressResolver {
                 AddressPrefixBuilder.Prefix(roadAddress, isTruncated = false)
             }
 
-        AnalysisUtil.debug("classify: road='$roadAddress' prefix='${prefixSpec.prefix}' truncated=${prefixSpec.isTruncated} prefixEnabled=$prefixEnabled")
-
         val first = queryAndCacheSiblings(prefixSpec.prefix, roadAddress, prefixEnabled, eventParam) ?: return markUnknown(poi)
 
         // matchedPlaceId 추출 때문에 boolean 대신 질의 결과를 들고 간다. null 이면 NotSearchable.
@@ -146,7 +144,6 @@ object DestinationAddressResolver {
         )
         cacheClient.cache(roadAddress, searchable = searchable, placesId = resolved?.matchedPlaceId)
         val result = if (searchable) Searchability.Searchable else Searchability.NotSearchable
-        AnalysisUtil.debug("classify: verdict=$result road='$roadAddress' placesId=${resolved?.matchedPlaceId}")
         AppRepository.getInstance().markClassified(poi, result)
         return result
     }
@@ -173,14 +170,7 @@ object DestinationAddressResolver {
                 AnalysisUtil.recordException(e)
                 return null
             }
-        AnalysisUtil.debug(
-            "places query='$queryInput' target='$target' matched=${result.matched} matchedPlaceId=${result.matchedPlaceId} " +
-                "predictions=${result.predictions.map { "${it.fullText}|${it.placeId}" }}",
-        )
-        if (prefixEnabled) {
-            cacheClient.cacheSiblings(result.predictions)
-            AnalysisUtil.debug("cacheSiblings: ${result.predictions.size}건 기록")
-        }
+        if (prefixEnabled) cacheClient.cacheSiblings(result.predictions)
         return result
     }
 

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolver.kt
@@ -127,11 +127,18 @@ object DestinationAddressResolver {
         // prefix 에서 못 찾고 prefix≠full(절단) 이면, prefix 자동완성 누락 가능성이 있어 full 로 한 번 더 확인한다.
         val resolved: AutocompleteResult? =
             when {
-                first.matched -> first
-                prefixSpec.isTruncated ->
+                first.matched -> {
+                    first
+                }
+
+                prefixSpec.isTruncated -> {
                     (queryAndCacheSiblings(roadAddress, roadAddress, prefixEnabled, eventParam) ?: return markUnknown(poi))
                         .takeIf { it.matched }
-                else -> null
+                }
+
+                else -> {
+                    null
+                }
             }
 
         val searchable = resolved != null

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteCacheClient.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteCacheClient.kt
@@ -69,12 +69,10 @@ object FirestorePlaceAutocompleteCacheClient : PlaceAutocompleteCacheClient {
         placesId: String?,
     ) {
         try {
-            val canonical = AddressCanonicalizer.canonicalize(address)
-            AnalysisUtil.debug("cache target: '$address' -> canonical='$canonical' searchable=$searchable placesId=$placesId")
             FirebaseFirestore
                 .getInstance()
                 .collection(COLLECTION)
-                .document(hash(canonical))
+                .document(hash(AddressCanonicalizer.canonicalize(address)))
                 .set(buildDoc(searchable, placesId, computeExpiresAt()))
                 .await()
         } catch (e: CancellationException) {
@@ -92,12 +90,10 @@ object FirestorePlaceAutocompleteCacheClient : PlaceAutocompleteCacheClient {
             // TTL/expiresAt 은 배치 전체에서 한 번만 계산해 재사용한다(형제별 RemoteConfig 읽기 방지).
             val expiresAt = computeExpiresAt()
             siblings.forEach { p ->
-                val canonical = AddressCanonicalizer.canonicalize(p.fullText)
-                AnalysisUtil.debug("cache sibling: '${p.fullText}' -> canonical='$canonical' placeId=${p.placeId}")
                 val ref =
                     db
                         .collection(COLLECTION)
-                        .document(hash(canonical))
+                        .document(hash(AddressCanonicalizer.canonicalize(p.fullText)))
                 batch.set(ref, buildDoc(searchable = true, placesId = p.placeId, expiresAt = expiresAt))
             }
             batch.commit().await()

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteCacheClient.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteCacheClient.kt
@@ -23,7 +23,11 @@ interface PlaceAutocompleteCacheClient {
     suspend fun cache(
         address: String,
         searchable: Boolean,
+        placesId: String? = null,
     )
+
+    /** 예측 전부를 Searchable 로 일괄 기록 (배치). */
+    suspend fun cacheSiblings(siblings: List<PlacePrediction>)
 }
 
 object FirestorePlaceAutocompleteCacheClient : PlaceAutocompleteCacheClient {
@@ -31,6 +35,7 @@ object FirestorePlaceAutocompleteCacheClient : PlaceAutocompleteCacheClient {
     private const val FIELD_SEARCHABLE = "searchable"
     private const val FIELD_EXPIRES_AT = "expiresAt"
     private const val FIELD_CREATED_AT = "createdAt"
+    private const val FIELD_PLACES_ID = "placesId"
     private const val DEFAULT_TTL_DAYS = 30L
 
     override suspend fun lookup(address: String): PlaceAutocompleteCacheEntry? =
@@ -39,7 +44,7 @@ object FirestorePlaceAutocompleteCacheClient : PlaceAutocompleteCacheClient {
                 FirebaseFirestore
                     .getInstance()
                     .collection(COLLECTION)
-                    .document(hash(address))
+                    .document(hash(AddressCanonicalizer.canonicalize(address)))
                     .get()
                     .await()
             if (!doc.exists()) {
@@ -61,26 +66,55 @@ object FirestorePlaceAutocompleteCacheClient : PlaceAutocompleteCacheClient {
     override suspend fun cache(
         address: String,
         searchable: Boolean,
+        placesId: String?,
     ) {
         try {
-            val ttlDays = RemoteConfigUtil.getLong(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_TTL_DAYS).takeIf { it > 0L } ?: DEFAULT_TTL_DAYS
-            val expiresAt = Timestamp(Date(System.currentTimeMillis() + ttlDays * 24L * 60L * 60L * 1000L))
             FirebaseFirestore
                 .getInstance()
                 .collection(COLLECTION)
-                .document(hash(address))
-                .set(
-                    mapOf(
-                        FIELD_SEARCHABLE to searchable,
-                        FIELD_EXPIRES_AT to expiresAt,
-                        FIELD_CREATED_AT to FieldValue.serverTimestamp(),
-                    ),
-                ).await()
+                .document(hash(AddressCanonicalizer.canonicalize(address)))
+                .set(buildDoc(searchable, placesId))
+                .await()
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             AnalysisUtil.recordException(e)
         }
+    }
+
+    override suspend fun cacheSiblings(siblings: List<PlacePrediction>) {
+        if (siblings.isEmpty()) return
+        try {
+            val db = FirebaseFirestore.getInstance()
+            val batch = db.batch()
+            siblings.forEach { p ->
+                val ref =
+                    db
+                        .collection(COLLECTION)
+                        .document(hash(AddressCanonicalizer.canonicalize(p.fullText)))
+                batch.set(ref, buildDoc(searchable = true, placesId = p.placeId))
+            }
+            batch.commit().await()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            AnalysisUtil.recordException(e)
+        }
+    }
+
+    private fun buildDoc(
+        searchable: Boolean,
+        placesId: String?,
+    ): Map<String, Any> {
+        val ttlDays = RemoteConfigUtil.getLong(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_TTL_DAYS).takeIf { it > 0L } ?: DEFAULT_TTL_DAYS
+        val expiresAt = Timestamp(Date(System.currentTimeMillis() + ttlDays * 24L * 60L * 60L * 1000L))
+        val base =
+            mapOf(
+                FIELD_SEARCHABLE to searchable,
+                FIELD_EXPIRES_AT to expiresAt,
+                FIELD_CREATED_AT to FieldValue.serverTimestamp(),
+            )
+        return if (placesId != null) base + (FIELD_PLACES_ID to placesId) else base
     }
 
     private fun hash(address: String): String {

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteCacheClient.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteCacheClient.kt
@@ -73,7 +73,7 @@ object FirestorePlaceAutocompleteCacheClient : PlaceAutocompleteCacheClient {
                 .getInstance()
                 .collection(COLLECTION)
                 .document(hash(AddressCanonicalizer.canonicalize(address)))
-                .set(buildDoc(searchable, placesId))
+                .set(buildDoc(searchable, placesId, computeExpiresAt()))
                 .await()
         } catch (e: CancellationException) {
             throw e
@@ -87,12 +87,14 @@ object FirestorePlaceAutocompleteCacheClient : PlaceAutocompleteCacheClient {
         try {
             val db = FirebaseFirestore.getInstance()
             val batch = db.batch()
+            // TTL/expiresAt 은 배치 전체에서 한 번만 계산해 재사용한다(형제별 RemoteConfig 읽기 방지).
+            val expiresAt = computeExpiresAt()
             siblings.forEach { p ->
                 val ref =
                     db
                         .collection(COLLECTION)
                         .document(hash(AddressCanonicalizer.canonicalize(p.fullText)))
-                batch.set(ref, buildDoc(searchable = true, placesId = p.placeId))
+                batch.set(ref, buildDoc(searchable = true, placesId = p.placeId, expiresAt = expiresAt))
             }
             batch.commit().await()
         } catch (e: CancellationException) {
@@ -102,12 +104,16 @@ object FirestorePlaceAutocompleteCacheClient : PlaceAutocompleteCacheClient {
         }
     }
 
+    private fun computeExpiresAt(): Timestamp {
+        val ttlDays = RemoteConfigUtil.getLong(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_TTL_DAYS).takeIf { it > 0L } ?: DEFAULT_TTL_DAYS
+        return Timestamp(Date(System.currentTimeMillis() + ttlDays * 24L * 60L * 60L * 1000L))
+    }
+
     private fun buildDoc(
         searchable: Boolean,
         placesId: String?,
+        expiresAt: Timestamp,
     ): Map<String, Any> {
-        val ttlDays = RemoteConfigUtil.getLong(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_TTL_DAYS).takeIf { it > 0L } ?: DEFAULT_TTL_DAYS
-        val expiresAt = Timestamp(Date(System.currentTimeMillis() + ttlDays * 24L * 60L * 60L * 1000L))
         val base =
             mapOf(
                 FIELD_SEARCHABLE to searchable,

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteCacheClient.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteCacheClient.kt
@@ -69,10 +69,12 @@ object FirestorePlaceAutocompleteCacheClient : PlaceAutocompleteCacheClient {
         placesId: String?,
     ) {
         try {
+            val canonical = AddressCanonicalizer.canonicalize(address)
+            AnalysisUtil.debug("cache target: '$address' -> canonical='$canonical' searchable=$searchable placesId=$placesId")
             FirebaseFirestore
                 .getInstance()
                 .collection(COLLECTION)
-                .document(hash(AddressCanonicalizer.canonicalize(address)))
+                .document(hash(canonical))
                 .set(buildDoc(searchable, placesId, computeExpiresAt()))
                 .await()
         } catch (e: CancellationException) {
@@ -90,10 +92,12 @@ object FirestorePlaceAutocompleteCacheClient : PlaceAutocompleteCacheClient {
             // TTL/expiresAt 은 배치 전체에서 한 번만 계산해 재사용한다(형제별 RemoteConfig 읽기 방지).
             val expiresAt = computeExpiresAt()
             siblings.forEach { p ->
+                val canonical = AddressCanonicalizer.canonicalize(p.fullText)
+                AnalysisUtil.debug("cache sibling: '${p.fullText}' -> canonical='$canonical' placeId=${p.placeId}")
                 val ref =
                     db
                         .collection(COLLECTION)
-                        .document(hash(AddressCanonicalizer.canonicalize(p.fullText)))
+                        .document(hash(canonical))
                 batch.set(ref, buildDoc(searchable = true, placesId = p.placeId, expiresAt = expiresAt))
             }
             batch.commit().await()

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteCacheClient.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteCacheClient.kt
@@ -113,15 +113,13 @@ object FirestorePlaceAutocompleteCacheClient : PlaceAutocompleteCacheClient {
         searchable: Boolean,
         placesId: String?,
         expiresAt: Timestamp,
-    ): Map<String, Any> {
-        val base =
-            mapOf(
-                FIELD_SEARCHABLE to searchable,
-                FIELD_EXPIRES_AT to expiresAt,
-                FIELD_CREATED_AT to FieldValue.serverTimestamp(),
-            )
-        return if (placesId != null) base + (FIELD_PLACES_ID to placesId) else base
-    }
+    ): Map<String, Any> =
+        buildMap {
+            put(FIELD_SEARCHABLE, searchable)
+            put(FIELD_EXPIRES_AT, expiresAt)
+            put(FIELD_CREATED_AT, FieldValue.serverTimestamp())
+            if (placesId != null) put(FIELD_PLACES_ID, placesId)
+        }
 
     private fun hash(address: String): String {
         val digest = MessageDigest.getInstance("SHA-256")

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteMatcher.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteMatcher.kt
@@ -1,5 +1,8 @@
 package me.zipi.navitotesla.service.place
 
+/** Places Autocomplete 응답 최대 건수(API 페이지 상한). size==이 값이면 절단됐을 수 있다. */
+const val MAX_PREDICTIONS = 5
+
 /** SDK 비의존 도메인 예측. fullText 는 캐시키 정규화 전 원문. */
 data class PlacePrediction(
     val fullText: String,
@@ -28,7 +31,7 @@ class RealPlaceAutocompleteMatcher(
         return AutocompleteResult(
             predictions = predictions,
             matched = matchedIdx >= 0,
-            matchedPlaceId = matchedIdx.takeIf { it >= 0 }?.let { predictions[it].placeId },
+            matchedPlaceId = predictions.getOrNull(matchedIdx)?.placeId,
         )
     }
 }

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteMatcher.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteMatcher.kt
@@ -9,6 +9,7 @@ data class PlacePrediction(
 data class AutocompleteResult(
     val predictions: List<PlacePrediction>,
     val matched: Boolean,
+    val matchedPlaceId: String?,
 )
 
 interface PlaceAutocompleteMatcher {
@@ -21,9 +22,13 @@ class RealPlaceAutocompleteMatcher(
 ) : PlaceAutocompleteMatcher {
     override suspend fun query(input: String): AutocompleteResult {
         val raw = client.fetchPredictions(input)
-        val matched = roadNumberMatcher.matches(input, raw)
         val predictions =
             raw.map { PlacePrediction(fullText = it.getFullText(null).toString(), placeId = it.placeId) }
-        return AutocompleteResult(predictions = predictions, matched = matched)
+        val matchedIdx = raw.indexOfFirst { roadNumberMatcher.matches(input, listOf(it)) }
+        return AutocompleteResult(
+            predictions = predictions,
+            matched = matchedIdx >= 0,
+            matchedPlaceId = matchedIdx.takeIf { it >= 0 }?.let { predictions[it].placeId },
+        )
     }
 }

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteMatcher.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteMatcher.kt
@@ -1,8 +1,5 @@
 package me.zipi.navitotesla.service.place
 
-/** Places Autocomplete 응답 최대 건수(API 페이지 상한). size==이 값이면 절단됐을 수 있다. */
-const val MAX_PREDICTIONS = 5
-
 /** SDK 비의존 도메인 예측. fullText 는 캐시키 정규화 전 원문. */
 data class PlacePrediction(
     val fullText: String,
@@ -16,18 +13,28 @@ data class AutocompleteResult(
 )
 
 interface PlaceAutocompleteMatcher {
-    suspend fun query(input: String): AutocompleteResult
+    /**
+     * [queryInput] 으로 자동완성을 조회하되, 매칭은 항상 [target](목적지 도로명주소) 기준으로 한다.
+     * prefix 조회 시 queryInput(잘린 prefix)≠target 이므로 둘을 분리해야 한다.
+     */
+    suspend fun query(
+        queryInput: String,
+        target: String,
+    ): AutocompleteResult
 }
 
 class RealPlaceAutocompleteMatcher(
     private val client: PlacesAutocompleteClient = PlacesAutocompleteClient,
     private val roadNumberMatcher: RoadNumberMatcher = RoadNumberMatcher(),
 ) : PlaceAutocompleteMatcher {
-    override suspend fun query(input: String): AutocompleteResult {
-        val raw = client.fetchPredictions(input)
+    override suspend fun query(
+        queryInput: String,
+        target: String,
+    ): AutocompleteResult {
+        val raw = client.fetchPredictions(queryInput)
         val predictions =
             raw.map { PlacePrediction(fullText = it.getFullText(null).toString(), placeId = it.placeId) }
-        val matchedIdx = raw.indexOfFirst { roadNumberMatcher.matches(input, listOf(it)) }
+        val matchedIdx = raw.indexOfFirst { roadNumberMatcher.matches(target, listOf(it)) }
         return AutocompleteResult(
             predictions = predictions,
             matched = matchedIdx >= 0,

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteMatcher.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlaceAutocompleteMatcher.kt
@@ -1,15 +1,29 @@
 package me.zipi.navitotesla.service.place
 
+/** SDK 비의존 도메인 예측. fullText 는 캐시키 정규화 전 원문. */
+data class PlacePrediction(
+    val fullText: String,
+    val placeId: String?,
+)
+
+data class AutocompleteResult(
+    val predictions: List<PlacePrediction>,
+    val matched: Boolean,
+)
+
 interface PlaceAutocompleteMatcher {
-    suspend fun isMatch(input: String): Boolean
+    suspend fun query(input: String): AutocompleteResult
 }
 
 class RealPlaceAutocompleteMatcher(
     private val client: PlacesAutocompleteClient = PlacesAutocompleteClient,
     private val roadNumberMatcher: RoadNumberMatcher = RoadNumberMatcher(),
 ) : PlaceAutocompleteMatcher {
-    override suspend fun isMatch(input: String): Boolean {
-        val predictions = client.fetchPredictions(input)
-        return roadNumberMatcher.matches(input, predictions)
+    override suspend fun query(input: String): AutocompleteResult {
+        val raw = client.fetchPredictions(input)
+        val matched = roadNumberMatcher.matches(input, raw)
+        val predictions =
+            raw.map { PlacePrediction(fullText = it.getFullText(null).toString(), placeId = it.placeId) }
+        return AutocompleteResult(predictions = predictions, matched = matched)
     }
 }

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlacesAutocompleteClient.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/PlacesAutocompleteClient.kt
@@ -1,7 +1,6 @@
 package me.zipi.navitotesla.service.place
 
 import com.google.android.libraries.places.api.model.AutocompletePrediction
-import com.google.android.libraries.places.api.model.AutocompleteSessionToken
 import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRequest
 import com.google.android.libraries.places.api.net.PlacesClient
 import kotlinx.coroutines.tasks.await
@@ -17,14 +16,13 @@ object PlacesAutocompleteClient {
     @Throws(Exception::class)
     suspend fun fetchPredictions(input: String): List<AutocompletePrediction> {
         val c = client ?: throw IllegalStateException("Places client not initialized")
-        val token = AutocompleteSessionToken.newInstance()
         val request =
             FindAutocompletePredictionsRequest
                 .builder()
-                .setSessionToken(token)
                 .setQuery(input)
                 .setCountries("KR")
                 .setRegionCode("KR")
+                .setTypesFilter(listOf("street_address"))
                 .build()
         return c.findAutocompletePredictions(request).await().autocompletePredictions
     }

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/RemoteConfigUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/RemoteConfigUtil.kt
@@ -13,6 +13,7 @@ object RemoteConfigUtil {
     const val KEY_GOOGLE_PLACE_CHECK_TTL_DAYS = "googlePlaceCheckTtlDays"
     const val KEY_GOOGLE_PLACE_CHECK_COOLDOWN_HOURS = "googlePlaceCheckCooldownHours"
     const val KEY_SEND_UNKNOWN_AS_NOT_SEARCHABLE = "sendUnknownAsNotSearchable"
+    const val KEY_GOOGLE_PLACE_PREFIX_ENABLED = "googlePlacePrefixEnabled"
     private const val FETCH_INTERVAL_SECONDS = 20 * 3600L
     private const val DEFAULT_VALUE = "default"
 

--- a/app/src/main/res/xml/remote_config_defaults.xml
+++ b/app/src/main/res/xml/remote_config_defaults.xml
@@ -48,4 +48,8 @@
         <key>sendUnknownAsNotSearchable</key>
         <value>false</value>
     </entry>
+    <entry>
+        <key>googlePlacePrefixEnabled</key>
+        <value>false</value>
+    </entry>
 </defaultsMap><!-- END xml_defaults -->

--- a/app/src/test/kotlin/me/zipi/navitotesla/service/place/AddressCanonicalizerTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/service/place/AddressCanonicalizerTest.kt
@@ -1,0 +1,33 @@
+package me.zipi.navitotesla.service.place
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AddressCanonicalizerTest {
+    @Test
+    fun `strips 대한민국 prefix`() {
+        assertEquals(
+            "서울특별시 강남구 영동대로 513",
+            AddressCanonicalizer.canonicalize("대한민국 서울특별시 강남구 영동대로 513"),
+        )
+    }
+
+    @Test
+    fun `collapses internal whitespace and trims`() {
+        assertEquals(
+            "서울특별시 강남구 영동대로 513",
+            AddressCanonicalizer.canonicalize("  서울특별시   강남구  영동대로 513 "),
+        )
+    }
+
+    @Test
+    fun `is identity for clean kakao address`() {
+        val kakao = "서울특별시 중구 세종대로 110"
+        assertEquals(kakao, AddressCanonicalizer.canonicalize(kakao))
+    }
+
+    @Test
+    fun `does not strip 대한민국 when not a leading token`() {
+        assertEquals("서울 대한민국로 1", AddressCanonicalizer.canonicalize("서울 대한민국로 1"))
+    }
+}

--- a/app/src/test/kotlin/me/zipi/navitotesla/service/place/AddressPrefixBuilderTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/service/place/AddressPrefixBuilderTest.kt
@@ -1,0 +1,50 @@
+package me.zipi.navitotesla.service.place
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AddressPrefixBuilderTest {
+    @Test
+    fun `truncates last digit of multi-digit number`() {
+        val r = AddressPrefixBuilder.build("서울특별시 강남구 영동대로 1234")
+        assertEquals("서울특별시 강남구 영동대로 123", r.prefix)
+        assertTrue(r.isTruncated)
+    }
+
+    @Test
+    fun `truncates trailing char of sub-number`() {
+        val r = AddressPrefixBuilder.build("영동대로 1234-1")
+        assertEquals("영동대로 1234-", r.prefix)
+        assertTrue(r.isTruncated)
+    }
+
+    @Test
+    fun `single-digit building number is not truncated`() {
+        val r = AddressPrefixBuilder.build("영동대로 1")
+        assertEquals("영동대로 1", r.prefix)
+        assertFalse(r.isTruncated)
+    }
+
+    @Test
+    fun `non-numeric tail is not truncated`() {
+        val r = AddressPrefixBuilder.build("영동대로1길")
+        assertEquals("영동대로1길", r.prefix)
+        assertFalse(r.isTruncated)
+    }
+
+    @Test
+    fun `trims before building prefix`() {
+        val r = AddressPrefixBuilder.build("  영동대로 1234  ")
+        assertEquals("영동대로 123", r.prefix)
+        assertTrue(r.isTruncated)
+    }
+
+    @Test
+    fun `empty stays empty`() {
+        val r = AddressPrefixBuilder.build("   ")
+        assertEquals("", r.prefix)
+        assertFalse(r.isTruncated)
+    }
+}

--- a/app/src/test/kotlin/me/zipi/navitotesla/service/place/AddressPrefixBuilderTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/service/place/AddressPrefixBuilderTest.kt
@@ -47,4 +47,11 @@ class AddressPrefixBuilderTest {
         assertEquals("", r.prefix)
         assertFalse(r.isTruncated)
     }
+
+    @Test
+    fun `single token without space truncates trailing digit`() {
+        val r = AddressPrefixBuilder.build("강남대로1234")
+        assertEquals("강남대로123", r.prefix)
+        assertTrue(r.isTruncated)
+    }
 }

--- a/app/src/test/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolverClassifyTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolverClassifyTest.kt
@@ -18,6 +18,7 @@ import me.zipi.navitotesla.util.RemoteConfigUtil
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -243,12 +244,19 @@ class DestinationAddressResolverClassifyTest {
             every { RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_PREFIX_ENABLED) } returns false
             every { RemoteConfigUtil.getLong(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_RATIO) } returns 100L
             fakeMatcher.results["서울특별시 중구 세종대로 110"] =
-                AutocompleteResult(listOf(PlacePrediction("대한민국 서울특별시 중구 세종대로 110", "pid")), matched = true)
+                AutocompleteResult(
+                    listOf(PlacePrediction("대한민국 서울특별시 중구 세종대로 110", "pid")),
+                    matched = true,
+                    matchedPlaceId = "pid",
+                )
 
             val result = DestinationAddressResolver.classify(poi)
 
             assertEquals(Searchability.Searchable, result)
             assertEquals("서울특별시 중구 세종대로 110" to true, fakeCache.cached.single())
+            assertEquals("pid", fakeCache.cachedPlacesId.single())
+            // prefix-disabled 경로는 형제 캐싱을 하지 않는다.
+            assertTrue(fakeCache.siblingBatches.isEmpty())
         }
 
     @Test
@@ -300,6 +308,7 @@ class DestinationAddressResolverClassifyTest {
                         PlacePrediction("대한민국 서울특별시 강남구 영동대로 1230", "p2"),
                     ),
                     matched = true,
+                    matchedPlaceId = "p1",
                 )
 
             val result = DestinationAddressResolver.classify(numberPoi)
@@ -308,6 +317,7 @@ class DestinationAddressResolverClassifyTest {
             assertEquals(listOf("서울특별시 강남구 영동대로 123"), fakeMatcher.queried) // 1호출만
             assertEquals(2, fakeCache.siblingBatches.single().size)
             assertEquals("서울특별시 강남구 영동대로 1234" to true, fakeCache.cached.single())
+            assertEquals("p1", fakeCache.cachedPlacesId.single())
         }
 
     @Test
@@ -319,6 +329,7 @@ class DestinationAddressResolverClassifyTest {
                 AutocompleteResult(
                     List(4) { PlacePrediction("대한민국 서울특별시 강남구 영동대로 12${it}0", "p$it") },
                     matched = false,
+                    matchedPlaceId = null,
                 )
 
             val result = DestinationAddressResolver.classify(numberPoi)
@@ -326,6 +337,10 @@ class DestinationAddressResolverClassifyTest {
             assertEquals(Searchability.NotSearchable, result)
             assertEquals(listOf("서울특별시 강남구 영동대로 123"), fakeMatcher.queried) // 1호출
             assertEquals("서울특별시 강남구 영동대로 1234" to false, fakeCache.cached.single())
+            assertEquals(null, fakeCache.cachedPlacesId.single())
+            // matched 여부와 무관하게 1차 형제 캐싱은 발생해야 한다.
+            assertEquals(1, fakeCache.siblingBatches.size)
+            assertEquals(4, fakeCache.siblingBatches.single().size)
         }
 
     @Test
@@ -337,12 +352,14 @@ class DestinationAddressResolverClassifyTest {
                 AutocompleteResult(
                     List(5) { PlacePrediction("대한민국 서울특별시 강남구 영동대로 12${it}9", "p$it") },
                     matched = false,
+                    matchedPlaceId = null,
                 )
             // 2차 full: 타깃 매칭
             fakeMatcher.results["서울특별시 강남구 영동대로 1234"] =
                 AutocompleteResult(
                     listOf(PlacePrediction("대한민국 서울특별시 강남구 영동대로 1234", "pT")),
                     matched = true,
+                    matchedPlaceId = "pT",
                 )
 
             val result = DestinationAddressResolver.classify(numberPoi)
@@ -353,6 +370,60 @@ class DestinationAddressResolverClassifyTest {
                 fakeMatcher.queried,
             ) // 2호출
             assertEquals(2, fakeCache.siblingBatches.size) // 1차+2차 형제 캐싱
+            // 2차 질의가 searchable 판정을 냈으므로 그 matchedPlaceId 가 저장되어야 한다.
+            assertEquals("pT", fakeCache.cachedPlacesId.single())
+        }
+
+    @Test
+    fun `prefix miss with exactly max but second query fails returns Unknown`() =
+        runBlocking {
+            enablePrefixFlow()
+            // 1차: 정확히 5건 + 타깃 미포함 → 모호 → 2차 full 시도
+            fakeMatcher.results["서울특별시 강남구 영동대로 123"] =
+                AutocompleteResult(
+                    List(5) { PlacePrediction("대한민국 서울특별시 강남구 영동대로 12${it}9", "p$it") },
+                    matched = false,
+                    matchedPlaceId = null,
+                )
+            // 2차 full 질의는 예외 → Unknown
+            fakeMatcher.throwForInput["서울특별시 강남구 영동대로 1234"] = RuntimeException("boom")
+
+            val result = DestinationAddressResolver.classify(numberPoi)
+
+            assertEquals(Searchability.Unknown, result)
+            assertEquals(
+                listOf("서울특별시 강남구 영동대로 123", "서울특별시 강남구 영동대로 1234"),
+                fakeMatcher.queried,
+            ) // 정확히 2호출
+        }
+
+    private val singleDigitPoi =
+        Poi(
+            poiName = "목적지",
+            roadAddress = "서울특별시 강남구 영동대로 5",
+            address = "",
+            latitude = null,
+            longitude = null,
+            packageName = "com.example",
+        )
+
+    @Test
+    fun `not truncated with exactly max and miss is not searchable in one call`() =
+        runBlocking {
+            enablePrefixFlow()
+            // 단자리 번지 → prefix 절단 없음(isTruncated=false). 5건 반환 + 미매칭 → 2차 없이 NotSearchable.
+            fakeMatcher.results["서울특별시 강남구 영동대로 5"] =
+                AutocompleteResult(
+                    List(5) { PlacePrediction("대한민국 서울특별시 강남구 영동대로 ${it}9", "p$it") },
+                    matched = false,
+                    matchedPlaceId = null,
+                )
+
+            val result = DestinationAddressResolver.classify(singleDigitPoi)
+
+            assertEquals(Searchability.NotSearchable, result)
+            assertEquals(listOf("서울특별시 강남구 영동대로 5"), fakeMatcher.queried) // 1호출
+            assertEquals("서울특별시 강남구 영동대로 5" to false, fakeCache.cached.single())
         }
 
     private fun entity(
@@ -379,6 +450,7 @@ class DestinationAddressResolverClassifyTest {
         var lookupResult: PlaceAutocompleteCacheEntry? = null
         var lookupCount: Int = 0
         val cached = mutableListOf<Pair<String, Boolean>>()
+        val cachedPlacesId = mutableListOf<String?>()
         val siblingBatches = mutableListOf<List<PlacePrediction>>()
 
         override suspend fun lookup(address: String): PlaceAutocompleteCacheEntry? {
@@ -392,6 +464,7 @@ class DestinationAddressResolverClassifyTest {
             placesId: String?,
         ) {
             cached += address to searchable
+            cachedPlacesId += placesId
         }
 
         override suspend fun cacheSiblings(siblings: List<PlacePrediction>) {
@@ -404,11 +477,13 @@ class DestinationAddressResolverClassifyTest {
         val results = mutableMapOf<String, AutocompleteResult>()
         val queried = mutableListOf<String>()
         var throwOnQuery: Throwable? = null
+        val throwForInput = mutableMapOf<String, Throwable>()
 
         override suspend fun query(input: String): AutocompleteResult {
             queried += input
+            throwForInput[input]?.let { throw it }
             throwOnQuery?.let { throw it }
-            return results[input] ?: AutocompleteResult(emptyList(), false)
+            return results[input] ?: AutocompleteResult(emptyList(), false, null)
         }
     }
 }

--- a/app/src/test/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolverClassifyTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolverClassifyTest.kt
@@ -321,10 +321,10 @@ class DestinationAddressResolverClassifyTest {
         }
 
     @Test
-    fun `prefix miss with fewer than max is not searchable in one call`() =
+    fun `prefix miss truncated then full miss is not searchable (two calls)`() =
         runBlocking {
             enablePrefixFlow()
-            // 4건만 반환(<5) + 타깃 미포함 → 전수 → NotSearchable, 2차 없음
+            // prefix 미매칭(건수 무관) → 절단됐으므로 항상 2차 full. full 도 미매칭(미설정=빈결과) → NotSearchable.
             fakeMatcher.results["서울특별시 강남구 영동대로 123"] =
                 AutocompleteResult(
                     List(4) { PlacePrediction("대한민국 서울특별시 강남구 영동대로 12${it}0", "p$it") },
@@ -335,19 +335,22 @@ class DestinationAddressResolverClassifyTest {
             val result = DestinationAddressResolver.classify(numberPoi)
 
             assertEquals(Searchability.NotSearchable, result)
-            assertEquals(listOf("서울특별시 강남구 영동대로 123"), fakeMatcher.queried) // 1호출
+            assertEquals(
+                listOf("서울특별시 강남구 영동대로 123", "서울특별시 강남구 영동대로 1234"),
+                fakeMatcher.queried,
+            ) // 1차 미스 → 2차 full = 2호출
             assertEquals("서울특별시 강남구 영동대로 1234" to false, fakeCache.cached.single())
             assertEquals(null, fakeCache.cachedPlacesId.single())
-            // matched 여부와 무관하게 1차 형제 캐싱은 발생해야 한다.
-            assertEquals(1, fakeCache.siblingBatches.size)
-            assertEquals(4, fakeCache.siblingBatches.single().size)
+            // 1차(4건)+2차(0건) 모두 형제 캐싱 시도.
+            assertEquals(2, fakeCache.siblingBatches.size)
+            assertEquals(4, fakeCache.siblingBatches[0].size)
         }
 
     @Test
-    fun `prefix miss with exactly max triggers full second query`() =
+    fun `prefix miss truncated then full hit is searchable (two calls)`() =
         runBlocking {
             enablePrefixFlow()
-            // 1차: 정확히 5건 + 타깃 미포함 → 모호 → 2차 full
+            // 1차 prefix 미매칭(건수와 무관) → 절단됐으므로 2차 full 로 확인
             fakeMatcher.results["서울특별시 강남구 영동대로 123"] =
                 AutocompleteResult(
                     List(5) { PlacePrediction("대한민국 서울특별시 강남구 영동대로 12${it}9", "p$it") },
@@ -479,11 +482,14 @@ class DestinationAddressResolverClassifyTest {
         var throwOnQuery: Throwable? = null
         val throwForInput = mutableMapOf<String, Throwable>()
 
-        override suspend fun query(input: String): AutocompleteResult {
-            queried += input
-            throwForInput[input]?.let { throw it }
+        override suspend fun query(
+            queryInput: String,
+            target: String,
+        ): AutocompleteResult {
+            queried += queryInput
+            throwForInput[queryInput]?.let { throw it }
             throwOnQuery?.let { throw it }
-            return results[input] ?: AutocompleteResult(emptyList(), false, null)
+            return results[queryInput] ?: AutocompleteResult(emptyList(), false, null)
         }
     }
 }

--- a/app/src/test/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolverClassifyTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/service/place/DestinationAddressResolverClassifyTest.kt
@@ -236,6 +236,22 @@ class DestinationAddressResolverClassifyTest {
         }
 
     @Test
+    fun `places match true caches searchable`() =
+        runBlocking {
+            every { RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED) } returns true
+            every { RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_ENABLED) } returns true
+            every { RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_PREFIX_ENABLED) } returns false
+            every { RemoteConfigUtil.getLong(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_RATIO) } returns 100L
+            fakeMatcher.results["서울특별시 중구 세종대로 110"] =
+                AutocompleteResult(listOf(PlacePrediction("대한민국 서울특별시 중구 세종대로 110", "pid")), matched = true)
+
+            val result = DestinationAddressResolver.classify(poi)
+
+            assertEquals(Searchability.Searchable, result)
+            assertEquals("서울특별시 중구 세종대로 110" to true, fakeCache.cached.single())
+        }
+
+    @Test
     fun `places api exception path records cooldown via markClassified(null)`() =
         runBlocking {
             coEvery { dao.findPoiByPackage(any(), any()) } returns null
@@ -249,10 +265,94 @@ class DestinationAddressResolverClassifyTest {
                 RemoteConfigUtil.getLong(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_RATIO)
             } returns 100L
             fakeCache.lookupResult = null
-            fakeMatcher.throwOnMatch = RuntimeException("rate limit")
+            fakeMatcher.throwOnQuery = RuntimeException("rate limit")
 
             assertSame(Searchability.Unknown, DestinationAddressResolver.classify(poi))
             io.mockk.coVerify { repo.markClassified(poi, Searchability.Unknown) }
+        }
+
+    private fun enablePrefixFlow() {
+        every { RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_LOOKUP_ENABLED) } returns true
+        every { RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_ENABLED) } returns true
+        every { RemoteConfigUtil.getBoolean(RemoteConfigUtil.KEY_GOOGLE_PLACE_PREFIX_ENABLED) } returns true
+        every { RemoteConfigUtil.getLong(RemoteConfigUtil.KEY_GOOGLE_PLACE_CHECK_UPDATE_RATIO) } returns 100L
+    }
+
+    private val numberPoi =
+        Poi(
+            poiName = "목적지",
+            roadAddress = "서울특별시 강남구 영동대로 1234",
+            address = "",
+            latitude = null,
+            longitude = null,
+            packageName = "com.example",
+        )
+
+    @Test
+    fun `prefix hit caches target and siblings as searchable`() =
+        runBlocking {
+            enablePrefixFlow()
+            // 1차 prefix "서울특별시 강남구 영동대로 123" 응답에 타깃 포함 + 형제
+            fakeMatcher.results["서울특별시 강남구 영동대로 123"] =
+                AutocompleteResult(
+                    listOf(
+                        PlacePrediction("대한민국 서울특별시 강남구 영동대로 1234", "p1"),
+                        PlacePrediction("대한민국 서울특별시 강남구 영동대로 1230", "p2"),
+                    ),
+                    matched = true,
+                )
+
+            val result = DestinationAddressResolver.classify(numberPoi)
+
+            assertEquals(Searchability.Searchable, result)
+            assertEquals(listOf("서울특별시 강남구 영동대로 123"), fakeMatcher.queried) // 1호출만
+            assertEquals(2, fakeCache.siblingBatches.single().size)
+            assertEquals("서울특별시 강남구 영동대로 1234" to true, fakeCache.cached.single())
+        }
+
+    @Test
+    fun `prefix miss with fewer than max is not searchable in one call`() =
+        runBlocking {
+            enablePrefixFlow()
+            // 4건만 반환(<5) + 타깃 미포함 → 전수 → NotSearchable, 2차 없음
+            fakeMatcher.results["서울특별시 강남구 영동대로 123"] =
+                AutocompleteResult(
+                    List(4) { PlacePrediction("대한민국 서울특별시 강남구 영동대로 12${it}0", "p$it") },
+                    matched = false,
+                )
+
+            val result = DestinationAddressResolver.classify(numberPoi)
+
+            assertEquals(Searchability.NotSearchable, result)
+            assertEquals(listOf("서울특별시 강남구 영동대로 123"), fakeMatcher.queried) // 1호출
+            assertEquals("서울특별시 강남구 영동대로 1234" to false, fakeCache.cached.single())
+        }
+
+    @Test
+    fun `prefix miss with exactly max triggers full second query`() =
+        runBlocking {
+            enablePrefixFlow()
+            // 1차: 정확히 5건 + 타깃 미포함 → 모호 → 2차 full
+            fakeMatcher.results["서울특별시 강남구 영동대로 123"] =
+                AutocompleteResult(
+                    List(5) { PlacePrediction("대한민국 서울특별시 강남구 영동대로 12${it}9", "p$it") },
+                    matched = false,
+                )
+            // 2차 full: 타깃 매칭
+            fakeMatcher.results["서울특별시 강남구 영동대로 1234"] =
+                AutocompleteResult(
+                    listOf(PlacePrediction("대한민국 서울특별시 강남구 영동대로 1234", "pT")),
+                    matched = true,
+                )
+
+            val result = DestinationAddressResolver.classify(numberPoi)
+
+            assertEquals(Searchability.Searchable, result)
+            assertEquals(
+                listOf("서울특별시 강남구 영동대로 123", "서울특별시 강남구 영동대로 1234"),
+                fakeMatcher.queried,
+            ) // 2호출
+            assertEquals(2, fakeCache.siblingBatches.size) // 1차+2차 형제 캐싱
         }
 
     private fun entity(
@@ -279,6 +379,7 @@ class DestinationAddressResolverClassifyTest {
         var lookupResult: PlaceAutocompleteCacheEntry? = null
         var lookupCount: Int = 0
         val cached = mutableListOf<Pair<String, Boolean>>()
+        val siblingBatches = mutableListOf<List<PlacePrediction>>()
 
         override suspend fun lookup(address: String): PlaceAutocompleteCacheEntry? {
             lookupCount++
@@ -288,18 +389,26 @@ class DestinationAddressResolverClassifyTest {
         override suspend fun cache(
             address: String,
             searchable: Boolean,
+            placesId: String?,
         ) {
             cached += address to searchable
+        }
+
+        override suspend fun cacheSiblings(siblings: List<PlacePrediction>) {
+            siblingBatches += siblings
         }
     }
 
     private class FakeMatcher : PlaceAutocompleteMatcher {
-        var matchResult: Boolean = false
-        var throwOnMatch: Throwable? = null
+        // 입력별 반환 결과. 미설정 입력은 빈 결과(매칭 실패).
+        val results = mutableMapOf<String, AutocompleteResult>()
+        val queried = mutableListOf<String>()
+        var throwOnQuery: Throwable? = null
 
-        override suspend fun isMatch(input: String): Boolean {
-            throwOnMatch?.let { throw it }
-            return matchResult
+        override suspend fun query(input: String): AutocompleteResult {
+            queried += input
+            throwOnQuery?.let { throw it }
+            return results[input] ?: AutocompleteResult(emptyList(), false)
         }
     }
 }

--- a/app/src/test/kotlin/me/zipi/navitotesla/service/place/RealPlaceAutocompleteMatcherTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/service/place/RealPlaceAutocompleteMatcherTest.kt
@@ -1,0 +1,37 @@
+package me.zipi.navitotesla.service.place
+
+import android.text.SpannableString
+import com.google.android.libraries.places.api.model.AutocompletePrediction
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RealPlaceAutocompleteMatcherTest {
+    private fun prediction(fullText: String, placeId: String): AutocompletePrediction {
+        val spannable = mockk<SpannableString>()
+        every { spannable.toString() } returns fullText
+        val p = mockk<AutocompletePrediction>()
+        every { p.getFullText(null) } returns spannable
+        every { p.placeId } returns placeId
+        return p
+    }
+
+    @Test
+    fun `query maps predictions and computes match`() = runBlocking {
+        val client = mockk<PlacesAutocompleteClient>()
+        coEvery { client.fetchPredictions("서울특별시 강남구 영동대로 513") } returns
+            listOf(prediction("대한민국 서울특별시 강남구 영동대로 513", "pid1"))
+        val matcher = RealPlaceAutocompleteMatcher(client = client)
+
+        val result = matcher.query("서울특별시 강남구 영동대로 513")
+
+        assertTrue(result.matched)
+        assertEquals(1, result.predictions.size)
+        assertEquals("대한민국 서울특별시 강남구 영동대로 513", result.predictions[0].fullText)
+        assertEquals("pid1", result.predictions[0].placeId)
+    }
+}

--- a/app/src/test/kotlin/me/zipi/navitotesla/service/place/RealPlaceAutocompleteMatcherTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/service/place/RealPlaceAutocompleteMatcherTest.kt
@@ -33,5 +33,6 @@ class RealPlaceAutocompleteMatcherTest {
         assertEquals(1, result.predictions.size)
         assertEquals("대한민국 서울특별시 강남구 영동대로 513", result.predictions[0].fullText)
         assertEquals("pid1", result.predictions[0].placeId)
+        assertEquals("pid1", result.matchedPlaceId)
     }
 }

--- a/app/src/test/kotlin/me/zipi/navitotesla/service/place/RealPlaceAutocompleteMatcherTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/service/place/RealPlaceAutocompleteMatcherTest.kt
@@ -27,12 +27,44 @@ class RealPlaceAutocompleteMatcherTest {
             listOf(prediction("대한민국 서울특별시 강남구 영동대로 513", "pid1"))
         val matcher = RealPlaceAutocompleteMatcher(client = client)
 
-        val result = matcher.query("서울특별시 강남구 영동대로 513")
+        val result = matcher.query("서울특별시 강남구 영동대로 513", "서울특별시 강남구 영동대로 513")
 
         assertTrue(result.matched)
         assertEquals(1, result.predictions.size)
         assertEquals("대한민국 서울특별시 강남구 영동대로 513", result.predictions[0].fullText)
         assertEquals("pid1", result.predictions[0].placeId)
         assertEquals("pid1", result.matchedPlaceId)
+    }
+
+    @Test
+    fun `match is against target not queryInput`() = runBlocking {
+        // prefix '사직로 16' 으로 조회하지만 매칭은 목적지 '사직로 161' 기준이어야 한다.
+        // 잘못 구현하면 prefix '16' 이 '사직로 16'(다른 건물)에 매칭돼 그 placeId 를 돌려준다.
+        val client = mockk<PlacesAutocompleteClient>()
+        coEvery { client.fetchPredictions("서울 종로구 사직로 16") } returns
+            listOf(
+                prediction("서울 종로구 사직로 161", "pid-161"),
+                prediction("서울 종로구 사직로 16", "pid-16"),
+            )
+        val matcher = RealPlaceAutocompleteMatcher(client = client)
+
+        val result = matcher.query("서울 종로구 사직로 16", "서울 종로구 사직로 161")
+
+        assertTrue(result.matched)
+        assertEquals("pid-161", result.matchedPlaceId)
+    }
+
+    @Test
+    fun `not matched when target absent even if queryInput matches a different prediction`() = runBlocking {
+        // prefix '사직로 16' 은 '사직로 16' 예측과 일치하지만, 목적지 '사직로 169' 는 예측에 없다 → 미매칭.
+        val client = mockk<PlacesAutocompleteClient>()
+        coEvery { client.fetchPredictions("서울 종로구 사직로 16") } returns
+            listOf(prediction("서울 종로구 사직로 16", "pid-16"))
+        val matcher = RealPlaceAutocompleteMatcher(client = client)
+
+        val result = matcher.query("서울 종로구 사직로 16", "서울 종로구 사직로 169")
+
+        assertEquals(false, result.matched)
+        assertEquals(null, result.matchedPlaceId)
     }
 }

--- a/app/src/test/kotlin/me/zipi/navitotesla/service/place/RealPlaceAutocompleteMatcherTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/service/place/RealPlaceAutocompleteMatcherTest.kt
@@ -11,7 +11,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class RealPlaceAutocompleteMatcherTest {
-    private fun prediction(fullText: String, placeId: String): AutocompletePrediction {
+    private fun prediction(
+        fullText: String,
+        placeId: String,
+    ): AutocompletePrediction {
         val spannable = mockk<SpannableString>()
         every { spannable.toString() } returns fullText
         val p = mockk<AutocompletePrediction>()
@@ -21,50 +24,53 @@ class RealPlaceAutocompleteMatcherTest {
     }
 
     @Test
-    fun `query maps predictions and computes match`() = runBlocking {
-        val client = mockk<PlacesAutocompleteClient>()
-        coEvery { client.fetchPredictions("서울특별시 강남구 영동대로 513") } returns
-            listOf(prediction("대한민국 서울특별시 강남구 영동대로 513", "pid1"))
-        val matcher = RealPlaceAutocompleteMatcher(client = client)
+    fun `query maps predictions and computes match`() =
+        runBlocking {
+            val client = mockk<PlacesAutocompleteClient>()
+            coEvery { client.fetchPredictions("서울특별시 강남구 영동대로 513") } returns
+                listOf(prediction("대한민국 서울특별시 강남구 영동대로 513", "pid1"))
+            val matcher = RealPlaceAutocompleteMatcher(client = client)
 
-        val result = matcher.query("서울특별시 강남구 영동대로 513", "서울특별시 강남구 영동대로 513")
+            val result = matcher.query("서울특별시 강남구 영동대로 513", "서울특별시 강남구 영동대로 513")
 
-        assertTrue(result.matched)
-        assertEquals(1, result.predictions.size)
-        assertEquals("대한민국 서울특별시 강남구 영동대로 513", result.predictions[0].fullText)
-        assertEquals("pid1", result.predictions[0].placeId)
-        assertEquals("pid1", result.matchedPlaceId)
-    }
-
-    @Test
-    fun `match is against target not queryInput`() = runBlocking {
-        // prefix '사직로 16' 으로 조회하지만 매칭은 목적지 '사직로 161' 기준이어야 한다.
-        // 잘못 구현하면 prefix '16' 이 '사직로 16'(다른 건물)에 매칭돼 그 placeId 를 돌려준다.
-        val client = mockk<PlacesAutocompleteClient>()
-        coEvery { client.fetchPredictions("서울 종로구 사직로 16") } returns
-            listOf(
-                prediction("서울 종로구 사직로 161", "pid-161"),
-                prediction("서울 종로구 사직로 16", "pid-16"),
-            )
-        val matcher = RealPlaceAutocompleteMatcher(client = client)
-
-        val result = matcher.query("서울 종로구 사직로 16", "서울 종로구 사직로 161")
-
-        assertTrue(result.matched)
-        assertEquals("pid-161", result.matchedPlaceId)
-    }
+            assertTrue(result.matched)
+            assertEquals(1, result.predictions.size)
+            assertEquals("대한민국 서울특별시 강남구 영동대로 513", result.predictions[0].fullText)
+            assertEquals("pid1", result.predictions[0].placeId)
+            assertEquals("pid1", result.matchedPlaceId)
+        }
 
     @Test
-    fun `not matched when target absent even if queryInput matches a different prediction`() = runBlocking {
-        // prefix '사직로 16' 은 '사직로 16' 예측과 일치하지만, 목적지 '사직로 169' 는 예측에 없다 → 미매칭.
-        val client = mockk<PlacesAutocompleteClient>()
-        coEvery { client.fetchPredictions("서울 종로구 사직로 16") } returns
-            listOf(prediction("서울 종로구 사직로 16", "pid-16"))
-        val matcher = RealPlaceAutocompleteMatcher(client = client)
+    fun `match is against target not queryInput`() =
+        runBlocking {
+            // prefix '사직로 16' 으로 조회하지만 매칭은 목적지 '사직로 161' 기준이어야 한다.
+            // 잘못 구현하면 prefix '16' 이 '사직로 16'(다른 건물)에 매칭돼 그 placeId 를 돌려준다.
+            val client = mockk<PlacesAutocompleteClient>()
+            coEvery { client.fetchPredictions("서울 종로구 사직로 16") } returns
+                listOf(
+                    prediction("서울 종로구 사직로 161", "pid-161"),
+                    prediction("서울 종로구 사직로 16", "pid-16"),
+                )
+            val matcher = RealPlaceAutocompleteMatcher(client = client)
 
-        val result = matcher.query("서울 종로구 사직로 16", "서울 종로구 사직로 169")
+            val result = matcher.query("서울 종로구 사직로 16", "서울 종로구 사직로 161")
 
-        assertEquals(false, result.matched)
-        assertEquals(null, result.matchedPlaceId)
-    }
+            assertTrue(result.matched)
+            assertEquals("pid-161", result.matchedPlaceId)
+        }
+
+    @Test
+    fun `not matched when target absent even if queryInput matches a different prediction`() =
+        runBlocking {
+            // prefix '사직로 16' 은 '사직로 16' 예측과 일치하지만, 목적지 '사직로 169' 는 예측에 없다 → 미매칭.
+            val client = mockk<PlacesAutocompleteClient>()
+            coEvery { client.fetchPredictions("서울 종로구 사직로 16") } returns
+                listOf(prediction("서울 종로구 사직로 16", "pid-16"))
+            val matcher = RealPlaceAutocompleteMatcher(client = client)
+
+            val result = matcher.query("서울 종로구 사직로 16", "서울 종로구 사직로 169")
+
+            assertEquals(false, result.matched)
+            assertEquals(null, result.matchedPlaceId)
+        }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -10,11 +10,13 @@ service cloud.firestore {
       allow read: if true;
 
       allow create, update: if
-        request.resource.data.keys().hasOnly(['searchable', 'expiresAt', 'createdAt'])
+        request.resource.data.keys().hasAll(['searchable', 'expiresAt', 'createdAt'])
+        && request.resource.data.keys().hasOnly(['searchable', 'expiresAt', 'createdAt', 'placesId'])
         && request.resource.data.searchable is bool
         && request.resource.data.expiresAt is timestamp
         && request.resource.data.expiresAt > request.time
-        && request.resource.data.createdAt == request.time;
+        && request.resource.data.createdAt == request.time
+        && (!('placesId' in request.resource.data) || request.resource.data.placesId is string);
 
       allow delete: if false;
     }


### PR DESCRIPTION
한 번의 Place API 자동완성 호출로 주변 형제 주소까지 함께 캐싱해 캐시 적중률을 높이고 API 호출을 줄입니다. (RemoteConfig 플래그로 기본 off)