### PR TITLE
fix(setting): 설정 토글 옵저버가 기본값을 저장소에 덮어쓰던 문제 수정

### DIFF
--- a/app/src/main/kotlin/me/zipi/navitotesla/ui/setting/SettingFragment.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/ui/setting/SettingFragment.kt
@@ -105,13 +105,14 @@ class SettingFragment :
     }
 
     private fun removeBluetoothDevice(position: Int) {
-        if (context == null || settingViewModel.bluetoothConditions.value == null) {
+        val name = settingViewModel.bluetoothConditions.value?.getOrNull(position) ?: return
+        if (context == null) {
             return
         }
-        settingViewModel.bluetoothConditions.value!![position]
-            .run { EnablerUtil.removeBluetoothCondition(this) }
-
-        updateConditions()
+        viewLifecycleOwner.lifecycleScope.launch {
+            EnablerUtil.removeBluetoothCondition(name).join()
+            settingViewModel.reloadBluetoothConditions()
+        }
     }
 
     override fun onResume() {
@@ -288,46 +289,23 @@ class SettingFragment :
 
     private fun updateConditions() =
         viewLifecycleOwner.lifecycleScope.launch {
-            if (context != null && activity != null) {
-                val appEnabled = context?.let { EnablerUtil.getAppEnabled() } ?: true
-                val conditionEnabled = context?.let { EnablerUtil.getConditionEnabled() } ?: false
+            if (context == null || activity == null) {
+                return@launch
+            }
+            // 앱 동작/조건/블루투스 상태는 ViewModel 이 저장소에서 로드한다(persist 하지 않음). 옵저버가 라디오/카드에 반영.
+            settingViewModel.loadStates()
+
+            launch {
                 val accEnabled: Boolean =
                     context?.let {
                         NaviToTeslaAccessibilityService.isAccessibilityServiceEnabled(context)
                     } ?: false
-
                 withContext(Dispatchers.Main) {
-                    binding.radioGroupAppEnable.check(if (appEnabled) binding.radioAppEnable.id else binding.radioAppDisable.id)
-                    binding.radioGroupConditionEnable.check(
-                        if (conditionEnabled) binding.radioConditionEnable.id else binding.radioConditionDisable.id,
-                    )
                     if (accEnabled) {
                         binding.radioAccEnable.isChecked = true
                     } else {
                         binding.radioAccDisable.isChecked = true
                     }
-                }
-            }
-
-            launch {
-                context?.run {
-                    settingViewModel.bluetoothConditions.postValue(
-                        EnablerUtil.listBluetoothCondition(),
-                    )
-                }
-            }
-            launch {
-                context?.run {
-                    settingViewModel.isAppEnabled.postValue(
-                        EnablerUtil.getAppEnabled(),
-                    )
-                }
-            }
-            launch {
-                context?.run {
-                    settingViewModel.isConditionEnabled.postValue(
-                        EnablerUtil.getConditionEnabled(),
-                    )
                 }
             }
             launch {
@@ -401,10 +379,8 @@ class SettingFragment :
                 val selectedDevice = dialogSpinner.selectedItem.toString()
                 lifecycleScope.launch {
                     if (context != null) {
-                        EnablerUtil.addBluetoothCondition(selectedDevice)
-                        settingViewModel.bluetoothConditions.postValue(
-                            EnablerUtil.listBluetoothCondition(),
-                        )
+                        EnablerUtil.addBluetoothCondition(selectedDevice).join()
+                        settingViewModel.reloadBluetoothConditions()
                     }
                 }
             }.setNegativeButton(activity.getString(R.string.close)) { _: DialogInterface?, _: Int -> }
@@ -441,12 +417,10 @@ class SettingFragment :
         return granted
     }
 
+    // 옵저버는 UI 반영만 한다. 저장은 사용자가 실제 토글했을 때(onCheckedChanged → ViewModel)만 일어난다.
+    // 옵저버에서 persist 하면 초기 기본값 재방출이 저장된 설정을 덮어쓴다(조건이 계속 비활성으로 돌아가던 버그).
     private fun onChangedAppEnabled(enabled: Boolean) {
-        lifecycleScope.launch {
-            if (context != null) {
-                EnablerUtil.setAppEnabled(enabled)
-            }
-        }
+        binding.radioGroupAppEnable.check(if (enabled) binding.radioAppEnable.id else binding.radioAppDisable.id)
     }
 
     private fun onChangedConditionEnabled(enabled: Boolean) {
@@ -460,11 +434,9 @@ class SettingFragment :
         }
         binding.cardBluetooth.visibility = if (enabled) View.VISIBLE else View.GONE
         conditionAnimReady = true
-        lifecycleScope.launch {
-            if (context != null) {
-                EnablerUtil.setConditionEnabled(enabled)
-            }
-        }
+        binding.radioGroupConditionEnable.check(
+            if (enabled) binding.radioConditionEnable.id else binding.radioConditionDisable.id,
+        )
     }
 
     override fun onCheckedChanged(
@@ -472,21 +444,13 @@ class SettingFragment :
         checkedId: Int,
     ) {
         if (checkedId == R.id.radioAppEnable) {
-            if (settingViewModel.isAppEnabled.value == false) {
-                settingViewModel.isAppEnabled.postValue(true)
-            }
+            settingViewModel.setAppEnabledByUser(true)
         } else if (checkedId == R.id.radioAppDisable) {
-            if (settingViewModel.isAppEnabled.value == true) {
-                settingViewModel.isAppEnabled.postValue(false)
-            }
+            settingViewModel.setAppEnabledByUser(false)
         } else if (checkedId == R.id.radioConditionEnable) {
-            if (settingViewModel.isConditionEnabled.value == false) {
-                settingViewModel.isConditionEnabled.postValue(true)
-            }
+            settingViewModel.setConditionEnabledByUser(true)
         } else if (checkedId == R.id.radioConditionDisable) {
-            if (settingViewModel.isConditionEnabled.value == true) {
-                settingViewModel.isConditionEnabled.postValue(false)
-            }
+            settingViewModel.setConditionEnabledByUser(false)
         } else if (checkedId == R.id.radioAccEnable) {
             if (activity != null &&
                 !NaviToTeslaAccessibilityService.isAccessibilityServiceEnabled(

--- a/app/src/main/kotlin/me/zipi/navitotesla/ui/setting/SettingViewModel.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/ui/setting/SettingViewModel.kt
@@ -3,6 +3,9 @@ package me.zipi.navitotesla.ui.setting
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import me.zipi.navitotesla.util.EnablerUtil
 
 class SettingViewModel : ViewModel() {
     val isAppEnabled = MutableLiveData(true)
@@ -10,6 +13,38 @@ class SettingViewModel : ViewModel() {
     val isConditionEnabled = MutableLiveData(false)
 
     val bluetoothConditions = MutableLiveData<List<String>>(emptyList())
+
+    /**
+     * 저장소의 현재 상태를 읽어 UI 상태(LiveData)에 반영한다.
+     * 로드 경로는 절대 저장소에 다시 쓰지 않는다 — 그래야 화면 재진입이 사용자 설정을 덮어쓰지 않는다.
+     */
+    fun loadStates() {
+        viewModelScope.launch {
+            isAppEnabled.value = EnablerUtil.getAppEnabled()
+            isConditionEnabled.value = EnablerUtil.getConditionEnabled()
+            bluetoothConditions.value = EnablerUtil.listBluetoothCondition()
+        }
+    }
+
+    fun reloadBluetoothConditions() {
+        viewModelScope.launch {
+            bluetoothConditions.value = EnablerUtil.listBluetoothCondition()
+        }
+    }
+
+    /** 사용자가 실제로 토글을 바꿨을 때만 호출한다. 값이 바뀔 때만 저장한다. */
+    fun setAppEnabledByUser(enabled: Boolean) {
+        if (isAppEnabled.value == enabled) return
+        isAppEnabled.value = enabled
+        viewModelScope.launch { EnablerUtil.setAppEnabled(enabled) }
+    }
+
+    /** 사용자가 실제로 토글을 바꿨을 때만 호출한다. 값이 바뀔 때만 저장한다. */
+    fun setConditionEnabledByUser(enabled: Boolean) {
+        if (isConditionEnabled.value == enabled) return
+        isConditionEnabled.value = enabled
+        viewModelScope.launch { EnablerUtil.setConditionEnabled(enabled) }
+    }
 
     fun clearObserve(owner: LifecycleOwner?) {
         isAppEnabled.removeObservers(owner!!)

--- a/app/src/test/kotlin/me/zipi/navitotesla/ui/setting/SettingViewModelTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/ui/setting/SettingViewModelTest.kt
@@ -1,0 +1,118 @@
+package me.zipi.navitotesla.ui.setting
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import me.zipi.navitotesla.TestApplication
+import me.zipi.navitotesla.util.AnalysisUtil
+import me.zipi.navitotesla.util.EnablerUtil
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * `SettingViewModel` 은 동작/조건 토글의 상태 소유 및 저장 책임을 가진다.
+ *
+ * 회귀 방지 핵심: **저장된 상태를 화면으로 "로드"하는 경로는 절대 저장소에 다시 쓰면 안 된다.**
+ * 과거에는 LiveData 옵저버가 초기 기본값(condition=false)을 그대로 persist 하여
+ * 사용자가 켜 둔 조건이 화면 재진입마다 false 로 덮어써졌다(= 리뷰의 "계속 비활성으로 바뀜").
+ * 저장은 오직 사용자가 실제로 토글을 바꿨을 때만 일어나야 한다.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], manifest = Config.NONE, application = TestApplication::class)
+class SettingViewModelTest {
+    private lateinit var viewModel: SettingViewModel
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+
+        mockkStatic(FirebaseCrashlytics::class)
+        every { FirebaseCrashlytics.getInstance() } returns mockk(relaxed = true)
+        mockkObject(AnalysisUtil)
+        every { AnalysisUtil.log(any()) } returns Unit
+
+        mockkObject(EnablerUtil)
+        coEvery { EnablerUtil.getAppEnabled() } returns true
+        coEvery { EnablerUtil.getConditionEnabled() } returns false
+        coEvery { EnablerUtil.listBluetoothCondition() } returns emptyList()
+        coEvery { EnablerUtil.setAppEnabled(any()) } returns Unit
+        coEvery { EnablerUtil.setConditionEnabled(any()) } returns Unit
+
+        viewModel = SettingViewModel()
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `loadStates 는 저장된 값을 반영하고 저장소에 다시 쓰지 않는다`() =
+        runTest {
+            coEvery { EnablerUtil.getAppEnabled() } returns false
+            coEvery { EnablerUtil.getConditionEnabled() } returns true
+
+            viewModel.loadStates()
+
+            assertEquals(false, viewModel.isAppEnabled.value)
+            assertEquals(true, viewModel.isConditionEnabled.value)
+            coVerify(exactly = 0) { EnablerUtil.setAppEnabled(any()) }
+            coVerify(exactly = 0) { EnablerUtil.setConditionEnabled(any()) }
+        }
+
+    @Test
+    fun `사용자가 조건을 켜면 true 가 저장되고 값이 갱신된다`() =
+        runTest {
+            // 현재 isConditionEnabled 기본값 = false
+            viewModel.setConditionEnabledByUser(true)
+
+            assertEquals(true, viewModel.isConditionEnabled.value)
+            coVerify(exactly = 1) { EnablerUtil.setConditionEnabled(true) }
+        }
+
+    @Test
+    fun `현재와 같은 값으로 조건 토글을 호출하면(복원-기본값 재방출) 저장하지 않는다`() =
+        runTest {
+            // 현재 isConditionEnabled 기본값 = false. 복원/초기 재방출 시 같은 false 가 들어온다.
+            viewModel.setConditionEnabledByUser(false)
+
+            coVerify(exactly = 0) { EnablerUtil.setConditionEnabled(any()) }
+        }
+
+    @Test
+    fun `사용자가 앱 동작을 끄면 false 가 저장되고 값이 갱신된다`() =
+        runTest {
+            // 현재 isAppEnabled 기본값 = true
+            viewModel.setAppEnabledByUser(false)
+
+            assertEquals(false, viewModel.isAppEnabled.value)
+            coVerify(exactly = 1) { EnablerUtil.setAppEnabled(false) }
+        }
+
+    @Test
+    fun `현재와 같은 값으로 앱 동작 토글을 호출하면 저장하지 않는다`() =
+        runTest {
+            // 현재 isAppEnabled 기본값 = true
+            viewModel.setAppEnabledByUser(true)
+
+            coVerify(exactly = 0) { EnablerUtil.setAppEnabled(any()) }
+        }
+}


### PR DESCRIPTION
## 문제
사용자 리뷰: 동작 조건(블루투스)을 켜 두었는데 **앱 업데이트 이후 계속 비활성으로 돌아간다**.

## 원인
`SettingFragment`의 LiveData 옵저버가 **초기 기본값을 그대로 저장소에 persist** 했다.
- `isConditionEnabled = MutableLiveData(false)` → 화면 진입 시 옵저버가 즉시 `false`로 발사 → `setConditionEnabled(false)`가 저장된 `appCondition=true`를 덮어씀
- `isAppEnabled`는 기본값 `true`라 무해 → **조건 토글만 깨지는 비대칭**이 리뷰 증상과 일치

## 수정
저장 책임을 `SettingViewModel`로 이동 (같은 화면 `duplicatePoi` / `HomeFragment.shareMode`의 검증된 패턴으로 통일).
- `loadStates()` — 저장소에서 읽어 UI 반영, **persist 안 함**
- `setAppEnabledByUser()` / `setConditionEnabledByUser()` — **값이 실제 바뀔 때만** 저장
- 옵저버는 라디오/카드 **UI 반영만** 담당 → 기본값/복원 재방출은 값 가드로 no-op
- 블루투스 추가/삭제 후 목록 갱신의 사전 존재 race 정리 (`.join()`)

## 유사 케이스 점검
전체 LiveData 옵저버 전수 조사 — 동일 버그는 Setting의 조건·앱 토글 2곳뿐. 나머지 옵저버는 UI 갱신만 함.

## 테스트
- 신규 `SettingViewModelTest` 5건 (RED→GREEN)
- 전체 단위 테스트 158개 통과 / ktlint 통과