### PR TITLE
chore(deps): update android sdk to 37

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,13 +10,13 @@ ksp {
     arg { listOf("room.schemaLocation=$projectDir/schemas") }
 }
 android {
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         buildConfigField("String", "BUILD_MODE", "\"playstore\"")
         applicationId = "me.zipi.navitotesla"
         minSdk = 24
-        targetSdk = 36
+        targetSdk = 37
 
         versionCode = Integer.parseInt(System.getenv("GITHUB_RUN_NUMBER") ?: "1")
         versionName = System.getenv("RELEASE") ?: "1.0"


### PR DESCRIPTION
compileSdk / targetSdk 를 36 → 37 로 올린다.

## 확인

- 빌드: nostoreDebug / playstoreDebug 정상
- 유닛테스트 158건 통과
- ktlint 통과
- Android lint: Error/Fatal 0건

## 참고

`platforms;android-37` 은 로컬에 없었지만 AGP 가 자동 설치했다.
build-tools 37.0.0 은 이미 있었다.