### PR TITLE
fix: 접근성 안내 문구 정리 및 라디오 UI 버그 수정

### DIFF
--- a/app/src/main/kotlin/me/zipi/navitotesla/background/TokenWorker.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/background/TokenWorker.kt
@@ -33,6 +33,11 @@ class TokenWorker(
         private const val WORKER_NAME = "refreshTokenWorker"
 
         suspend fun startBackgroundWork(context: Context) {
+            if (PreferencesUtil.getString("shareMode", "app") != "api") {
+                AnalysisUtil.log("Share mode is app. cancel token refresh work")
+                cancelBackgroundWork(context)
+                return
+            }
             if (PreferencesUtil.loadToken() == null) {
                 AnalysisUtil.log("Token is empty. add token refresh work ignore")
                 return

--- a/app/src/main/kotlin/me/zipi/navitotesla/ui/home/HomeFragment.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/ui/home/HomeFragment.kt
@@ -363,6 +363,10 @@ class HomeFragment :
         if (refreshToken.isNullOrEmpty()) {
             return
         }
+        // App 모드는 토큰을 쓰지 않는다. 조회하면 차량 없음 토스트만 뜬다.
+        if (PreferencesUtil.getStringSync("shareMode", "app") != "api") {
+            return
+        }
         if (!binding.btnSave.isEnabled) {
             return
         }
@@ -554,6 +558,8 @@ class HomeFragment :
         refreshTokenButtonEnabled()
         if (mode == "app") {
             overlayPermissionGrantedCheck()
+        } else {
+            getAccessTokenAndVehicles(homeViewModel.refreshToken.value)
         }
     }
 

--- a/app/src/main/kotlin/me/zipi/navitotesla/ui/setting/SettingFragment.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/ui/setting/SettingFragment.kt
@@ -49,8 +49,6 @@ class SettingFragment :
     private lateinit var settingViewModel: SettingViewModel
     private lateinit var binding: FragmentSettingsBinding
     private lateinit var conditionRecyclerAdapter: ConditionRecyclerAdapter
-    private var isDuplicatePoiRadioInitializing = false
-    private var isAccRadioUpdating = false
     private var diagnosticsUserToggled = false
     private var diagnosticsExpanded = false
     private var diagnosticsAnimReady = false
@@ -68,7 +66,8 @@ class SettingFragment :
         binding.btnAccEnableHelp.setOnClickListener(this)
         binding.radioGroupAppEnable.setOnCheckedChangeListener(this)
         binding.radioGroupConditionEnable.setOnCheckedChangeListener(this)
-        binding.radioGroupAccEnable.setOnCheckedChangeListener(this)
+        binding.radioAccEnable.setOnClickListener { onAccEnableClicked() }
+        binding.radioAccDisable.setOnClickListener { revokeAccessibilityConsent() }
         settingViewModel.isConditionEnabled
             .observe(viewLifecycleOwner) { enabled: Boolean -> onChangedConditionEnabled(enabled) }
         settingViewModel.isAppEnabled
@@ -101,7 +100,8 @@ class SettingFragment :
                 conditionRecyclerAdapter.setItems(items)
                 binding.textBluetoothEmpty.visibility = if (items.isNullOrEmpty()) View.VISIBLE else View.GONE
             }
-        binding.radioGroupDuplicatePoiSelection.setOnCheckedChangeListener(this)
+        binding.radioDuplicatePoiShowPopup.setOnClickListener { onDuplicatePoiSelected(true) }
+        binding.radioDuplicatePoiIgnore.setOnClickListener { onDuplicatePoiSelected(false) }
         return root
     }
 
@@ -304,11 +304,9 @@ class SettingFragment :
                 context?.run {
                     val enabled = PreferencesUtil.getBoolean("duplicatePoiSelection", true)
                     withContext(Dispatchers.Main) {
-                        isDuplicatePoiRadioInitializing = true
                         binding.radioGroupDuplicatePoiSelection.check(
                             if (enabled) binding.radioDuplicatePoiShowPopup.id else binding.radioDuplicatePoiIgnore.id,
                         )
-                        isDuplicatePoiRadioInitializing = false
                     }
                 }
             }
@@ -443,30 +441,24 @@ class SettingFragment :
             settingViewModel.setConditionEnabledByUser(true)
         } else if (checkedId == R.id.radioConditionDisable) {
             settingViewModel.setConditionEnabledByUser(false)
-        } else if (checkedId == R.id.radioAccEnable) {
-            if (!isAccRadioUpdating) {
-                // 동의 전에는 켜진 것으로 보이지 않아야 한다.
-                setAccRadio(false)
+        }
+    }
+
+    private fun onDuplicatePoiSelected(showPopup: Boolean) {
+        if (showPopup && context != null && !Settings.canDrawOverlays(requireContext())) {
+            showOverlayPermissionDialog()
+        }
+        lifecycleScope.launch { PreferencesUtil.put("duplicatePoiSelection", showPopup) }
+    }
+
+    private fun onAccEnableClicked() {
+        // 동의 전에는 켜진 것으로 보이지 않아야 한다.
+        setAccRadio(false)
+        viewLifecycleOwner.lifecycleScope.launch {
+            if (NaviToTeslaAccessibilityService.isActive(context)) {
+                setAccRadio(true)
+            } else {
                 showAccessibilityConsentDialog()
-            }
-        } else if (checkedId == R.id.radioDuplicatePoiShowPopup) {
-            if (!isDuplicatePoiRadioInitializing) {
-                if (context != null && !Settings.canDrawOverlays(requireContext())) {
-                    showOverlayPermissionDialog()
-                }
-                lifecycleScope.launch {
-                    PreferencesUtil.put("duplicatePoiSelection", true)
-                }
-            }
-        } else if (checkedId == R.id.radioDuplicatePoiIgnore) {
-            if (!isDuplicatePoiRadioInitializing) {
-                lifecycleScope.launch {
-                    PreferencesUtil.put("duplicatePoiSelection", false)
-                }
-            }
-        } else if (checkedId == R.id.radioAccDisable) {
-            if (!isAccRadioUpdating) {
-                revokeAccessibilityConsent()
             }
         }
     }
@@ -474,6 +466,9 @@ class SettingFragment :
     /** 동의를 회수하면 OS 접근성이 켜져 있어도 수집이 멈춘다. 서비스는 안드로이드 설정에서만 끌 수 있다. */
     private fun revokeAccessibilityConsent() =
         viewLifecycleOwner.lifecycleScope.launch {
+            if (!NaviToTeslaAccessibilityService.isConsented()) {
+                return@launch
+            }
             NaviToTeslaAccessibilityService.setConsent(false)
             val activity = activity ?: return@launch
             if (!NaviToTeslaAccessibilityService.isAccessibilityServiceEnabled(activity)) {
@@ -484,8 +479,8 @@ class SettingFragment :
                 .setTitle(getString(R.string.guide))
                 .setMessage(getString(R.string.disableAccessibility))
                 .setCancelable(true)
-                .setPositiveButton(getString(R.string.title_setting)) { _: DialogInterface?, _: Int -> openAccessibilitySettings() }
-                .setNegativeButton(getString(R.string.cancel)) { _: DialogInterface?, _: Int -> }
+                .setPositiveButton(getString(R.string.confirm)) { _: DialogInterface?, _: Int -> }
+                .setNegativeButton(getString(R.string.openAndroidSettings)) { _: DialogInterface?, _: Int -> openAccessibilitySettings() }
                 .create()
                 .show()
         }
@@ -493,13 +488,11 @@ class SettingFragment :
     private fun setAccRadio(enable: Boolean) {
         val activity = activity ?: return
         activity.runOnUiThread {
-            isAccRadioUpdating = true
             if (enable) {
                 binding.radioAccEnable.isChecked = true
             } else {
                 binding.radioAccDisable.isChecked = true
             }
-            isAccRadioUpdating = false
         }
     }
 
@@ -557,9 +550,7 @@ class SettingFragment :
                 lifecycleScope.launch {
                     PreferencesUtil.put("duplicatePoiSelection", false)
                     withContext(Dispatchers.Main) {
-                        isDuplicatePoiRadioInitializing = true
                         binding.radioGroupDuplicatePoiSelection.check(binding.radioDuplicatePoiIgnore.id)
-                        isDuplicatePoiRadioInitializing = false
                     }
                 }
             }.create()

--- a/app/src/main/res/layout-sw600dp-land/fragment_home.xml
+++ b/app/src/main/res/layout-sw600dp-land/fragment_home.xml
@@ -250,6 +250,7 @@
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="@dimen/space_xs"
+                            android:baselineAligned="false"
                             android:orientation="horizontal">
 
                             <com.google.android.material.radiobutton.MaterialRadioButton
@@ -298,6 +299,7 @@
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="@dimen/space_xs"
+                            android:baselineAligned="false"
                             android:orientation="horizontal">
 
                             <com.google.android.material.radiobutton.MaterialRadioButton

--- a/app/src/main/res/layout-sw600dp-land/fragment_settings.xml
+++ b/app/src/main/res/layout-sw600dp-land/fragment_settings.xml
@@ -69,6 +69,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/space_xs"
+                        android:baselineAligned="false"
                         android:orientation="horizontal">
 
                         <com.google.android.material.radiobutton.MaterialRadioButton
@@ -119,6 +120,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/space_xs"
+                        android:baselineAligned="false"
                         android:orientation="horizontal">
 
                         <com.google.android.material.radiobutton.MaterialRadioButton
@@ -258,6 +260,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/space_xs"
+                        android:baselineAligned="false"
                         android:orientation="horizontal">
 
                         <com.google.android.material.radiobutton.MaterialRadioButton
@@ -300,6 +303,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/space_xs"
+                        android:baselineAligned="false"
                         android:orientation="horizontal">
 
                         <com.google.android.material.radiobutton.MaterialRadioButton

--- a/app/src/main/res/layout/favorite_dialog_fragment.xml
+++ b/app/src/main/res/layout/favorite_dialog_fragment.xml
@@ -79,6 +79,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/space_xs"
             android:checkedButton="@id/radioRoadAddress"
+            android:baselineAligned="false"
             android:orientation="horizontal">
 
             <com.google.android.material.radiobutton.MaterialRadioButton

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -228,6 +228,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/space_xs"
+                    android:baselineAligned="false"
                     android:orientation="horizontal">
 
                     <com.google.android.material.radiobutton.MaterialRadioButton
@@ -276,6 +277,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/space_xs"
+                    android:baselineAligned="false"
                     android:orientation="horizontal">
 
                     <com.google.android.material.radiobutton.MaterialRadioButton

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -60,6 +60,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/space_xs"
+                    android:baselineAligned="false"
                     android:orientation="horizontal">
 
                     <com.google.android.material.radiobutton.MaterialRadioButton
@@ -102,6 +103,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/space_xs"
+                    android:baselineAligned="false"
                     android:orientation="horizontal">
 
                     <com.google.android.material.radiobutton.MaterialRadioButton
@@ -159,6 +161,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/space_xs"
+                    android:baselineAligned="false"
                     android:orientation="horizontal">
 
                     <com.google.android.material.radiobutton.MaterialRadioButton
@@ -201,6 +204,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/space_xs"
+                    android:baselineAligned="false"
                     android:orientation="horizontal">
 
                     <com.google.android.material.radiobutton.MaterialRadioButton

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -3,6 +3,7 @@
     <string name="cancel">Cancel</string>
     <string name="delete">Delete</string>
     <string name="send">Send</string>
+    <string name="openAndroidSettings">Android Settings</string>
     <string name="confirm">OK</string>
     <string name="guide">Guide</string>
     <string name="open">Open</string>
@@ -77,11 +78,11 @@
     <string name="enabledApp">Navi to Tesla is enabled</string>
     <string name="disabledApp">Navi to Tesla is disabled</string>
     <string name="accessibility_description">Navi to Tesla uses the Android accessibility service to obtain the destination from certain navigation apps.\n\n[Apps accessed]\n- NAVER Maps\n- Kakao Navi\n- These apps offer no way to obtain the destination without the accessibility service.\n\n[Information collected]\n- The driving destination\n- Whether route guidance is currently active\n\n[When it is collected]\n- When the navigation app starts guiding to a destination\n\n[Scope of screen reading]\n- Screens of other apps are not read.\n- Reads only the destination and the items needed to tell the driving mode apart.\n- Why both the destination screen and the driving screen are checked\n  - Identifying route guidance that starts without any user touch\n  - Preventing wrong sends in a drive-only mode with no destination\n\n[Purpose]\n- Sending the destination to the Tesla vehicle owned by the user\n- Caching the resolved address and coordinates on the device for a faster response\n\n[Stored information]\n- Stored items: destination name, resolved address, coordinates\n- Location: on the user\'s device\n- Cleanup: cached entries are removed automatically after a certain period\n\n[External sharing]\n- The Kakao and Naver APIs are called to resolve the destination into an address and coordinates.\n- The Google Places API is called to check whether the resolved address is searchable in the vehicle navigation.\n- The resolved destination is sent to the Tesla vehicle owned by the user.\n- The destination is not sent or shared with any other server or third party.\n\n[How to turn it off]\n- Can be turned off at any time in Android Settings.</string>
-    <string name="requireAccessibility">Requires accessibility services</string>
-    <string name="guideRequireAccessibility">For some navigation apps, you can use Navi to Tesla using accessibility services.\nDetails can be found in the Settings tab.</string>
+    <string name="requireAccessibility">Available with the accessibility service</string>
+    <string name="guideRequireAccessibility">This navigation app can be integrated through the accessibility service.\nSee the accessibility service notice in the Settings tab.</string>
     <string name="guideRequireRelaunch">Navi to Tesla has been updated. Please reopen.</string>
     <string name="accessibilityService">Accessibility Service</string>
-    <string name="disableAccessibility">Disable accessibility services. Navi to Tesla is not available on certain navigations.\nYou can disable the Navi to Tesla accessibility service in your Android settings.</string>
+    <string name="disableAccessibility">The accessibility service is now off. Destinations from some navigation apps are no longer sent.\nTo revoke the accessibility permission itself, turn it off in Android Settings.</string>
     <string name="guidePermissionDeny">You can grant permission again in Android\'s settings.</string>
     <string name="guideGrantNotificationPermission">By adding notification permissions, you can receive related notifications when Navi to Tesla operates.</string>
     <string name="duplicatePoiSelection">Duplicate destination</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -3,6 +3,7 @@
     <string name="cancel">취소</string>
     <string name="delete">삭제</string>
     <string name="send">전송</string>
+    <string name="openAndroidSettings">Android 설정</string>
     <string name="confirm">확인</string>
     <string name="guide">안내</string>
     <string name="open">열기</string>
@@ -77,11 +78,11 @@
     <string name="enabledApp">Navi to Tesla가 활성화 되었습니다</string>
     <string name="disabledApp">Navi to Tesla가 비활성화 되었습니다</string>
     <string name="accessibility_description">Navi to Tesla 는 특정 내비게이션의 목적지를 가져오기 위해 Android 접근성 기능을 사용합니다.\n\n[접근 대상 앱]\n- 네이버지도\n- 카카오내비\n- 해당 앱은 접근성 기능을 통하지 않고 목적지를 가져올 방법이 없습니다.\n\n[수집 정보]\n- 주행 목적지\n- 현재 주행 안내 중인지 여부\n\n[수집 시점]\n- 내비게이션이 목적지로 안내를 시작할 때\n\n[화면을 읽는 범위]\n- 다른 앱의 화면은 읽지 않습니다.\n- 목적지와 주행 모드 판별에 필요한 항목만 읽습니다.\n- 목적지 화면과 주행 화면을 함께 확인하는 이유\n  - 사용자 터치 없이 자동으로 시작되는 경로 안내 구분\n  - 목적지 없이 주행만 하는 모드(안전운전·안심주행)에서 오동작 방지\n\n[사용 목적]\n- 고객 본인 소유 Tesla 차량으로 목적지 전송\n- 빠른 응답을 위해 변환된 주소·좌표를 기기 내부에 임시 캐시\n\n[저장 정보]\n- 저장 대상: 목적지명, 변환된 주소, 좌표\n- 저장 위치: 사용자 기기 내부\n- 자동 정리: 일정 기간이 지난 캐시는 자동 삭제됩니다.\n\n[외부 공유 범위]\n- 목적지를 주소·좌표로 변환하기 위해 카카오·네이버 API를 호출합니다.\n- 변환된 주소를 차량 내비게이션에서 검색할 수 있는지 확인하기 위해 Google Places API를 호출합니다.\n- 변환된 목적지는 고객 본인 소유의 Tesla 차량으로 전송합니다.\n- 그 외 어떤 서버나 제3자에도 전송·공유하지 않습니다.\n\n[비활성화 방법]\n- Android 설정에서 언제든 끌 수 있습니다.</string>
-    <string name="requireAccessibility">접근성 서비스가 필요합니다</string>
-    <string name="guideRequireAccessibility">일부 내비게이션 앱의 경우 접근성 서비스를 이용하여 Navi to Tesla를 이용할 수 있습니다.\n자세한 내용은 설정탭에서 확인할 수 있습니다.</string>
+    <string name="requireAccessibility">접근성 기능으로 연동할 수 있습니다</string>
+    <string name="guideRequireAccessibility">해당 내비게이션은 접근성 기능을 통해 연동할 수 있습니다.\n설정 탭에서 접근성 서비스 안내를 확인해주세요.</string>
     <string name="guideRequireRelaunch">Navi to Tesla 업데이트가 적용되었습니다. 다시 실행해 주세요.</string>
     <string name="accessibilityService">접근성 서비스</string>
-    <string name="disableAccessibility">접근성 서비스를 비활성화합니다. 특정 내비게이션에서 Navi to Tesla를 사용할 수 없습니다. \n안드로이드 설정에서 Navi to Tesla 접근성 서비스를 비활성화할 수 있습니다.</string>
+    <string name="disableAccessibility">접근성 서비스를 비활성화했습니다. 일부 내비게이션의 목적지는 더 이상 전송되지 않습니다.\n접근성 권한 자체를 해제하려면 Android 설정에서 끌 수 있습니다.</string>
     <string name="guidePermissionDeny">안드로이드 설정 앱에서 언제든지 다시 권한을 부여할 수 있습니다.</string>
     <string name="guideGrantNotificationPermission">알림 권한을 추가하면 Navi to Tesla가 동작할 때 관련 알림을 받을 수 있습니다. </string>
     <string name="duplicatePoiSelection">중복 목적지 처리</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="cancel">Cancel</string>
     <string name="delete">Delete</string>
     <string name="send">Send</string>
+    <string name="openAndroidSettings">Android Settings</string>
     <string name="confirm">OK</string>
     <string name="guide">Guide</string>
     <string name="open">Open</string>
@@ -82,11 +83,11 @@
     <string name="enabledApp">Navi to Tesla is enabled</string>
     <string name="disabledApp">Navi to Tesla is disabled</string>
     <string name="accessibility_description">Navi to Tesla uses the Android accessibility service to obtain the destination from certain navigation apps.\n\n[Apps accessed]\n- NAVER Maps\n- Kakao Navi\n- These apps offer no way to obtain the destination without the accessibility service.\n\n[Information collected]\n- The driving destination\n- Whether route guidance is currently active\n\n[When it is collected]\n- When the navigation app starts guiding to a destination\n\n[Scope of screen reading]\n- Screens of other apps are not read.\n- Reads only the destination and the items needed to tell the driving mode apart.\n- Why both the destination screen and the driving screen are checked\n  - Identifying route guidance that starts without any user touch\n  - Preventing wrong sends in a drive-only mode with no destination\n\n[Purpose]\n- Sending the destination to the Tesla vehicle owned by the user\n- Caching the resolved address and coordinates on the device for a faster response\n\n[Stored information]\n- Stored items: destination name, resolved address, coordinates\n- Location: on the user\'s device\n- Cleanup: cached entries are removed automatically after a certain period\n\n[External sharing]\n- The Kakao and Naver APIs are called to resolve the destination into an address and coordinates.\n- The Google Places API is called to check whether the resolved address is searchable in the vehicle navigation.\n- The resolved destination is sent to the Tesla vehicle owned by the user.\n- The destination is not sent or shared with any other server or third party.\n\n[How to turn it off]\n- Can be turned off at any time in Android Settings.</string>
-    <string name="requireAccessibility">Requires accessibility services</string>
-    <string name="guideRequireAccessibility">For some navigation apps, you can use Navi to Tesla using accessibility services.\nDetails can be found in the Settings tab.</string>
+    <string name="requireAccessibility">Available with the accessibility service</string>
+    <string name="guideRequireAccessibility">This navigation app can be integrated through the accessibility service.\nSee the accessibility service notice in the Settings tab.</string>
     <string name="guideRequireRelaunch">Navi to Tesla has been updated. Please reopen.</string>
     <string name="accessibilityService">Accessibility Service</string>
-    <string name="disableAccessibility">Disable accessibility services. Navi to Tesla is not available on certain navigations.\nYou can disable the Navi to Tesla accessibility service in your Android settings.</string>
+    <string name="disableAccessibility">The accessibility service is now off. Destinations from some navigation apps are no longer sent.\nTo revoke the accessibility permission itself, turn it off in Android Settings.</string>
     <string name="guidePermissionDeny">You can grant permission again in Android\'s settings.</string>
     <string name="guideGrantNotificationPermission">By adding notification permissions, you can receive related notifications when Navi to Tesla operates.</string>
     <string name="duplicatePoiSelection">Duplicate destination</string>


### PR DESCRIPTION
## 접근성 안내 문구

- 알림·홈 다이얼로그 제목: `접근성 서비스가 필요합니다` → `접근성 기능으로 연동할 수 있습니다`
- 본문: `해당 내비게이션은 접근성 기능을 통해 연동할 수 있습니다. / 설정 탭에서 접근성 서비스 안내를 확인해주세요.`
- 비활성화 다이얼로그를 완료형으로 재작성. 누른 시점에 이미 연동이 꺼지는데 예고형이었고, `취소` 로도 되돌아가지 않았다
- 비활성화 다이얼로그 버튼을 `Android 설정`(좌) / `확인`(우) 으로 배치. `openAndroidSettings` 문자열 추가

## 라디오 클릭 처리

`onCheckedChanged` 는 사용자 탭뿐 아니라 뷰 상태 복원에서도 호출된다.
탭을 떠났다 돌아오면 복원된 체크 상태가 리스너를 태워 다이얼로그가 떴다.

- 접근성·중복 목적지 라디오를 `RadioGroup.setOnCheckedChangeListener` → `RadioButton.setOnClickListener` 로 전환
- `isAccRadioUpdating`, `isDuplicatePoiRadioInitializing` 플래그 제거
- 상태 판정을 동기 캐시가 아니라 `suspend` 조회로. 앱 재시작 직후 캐시 미적재 상태에서 오판하지 않는다

접근성 다이얼로그와 `다른 앱 위에 표시` 권한 다이얼로그가 모두 해당됐다.

## RadioGroup 정렬

수평 `RadioGroup` 은 `baselineAligned` 기본값이 `true` 라 자식을 텍스트 베이스라인으로 정렬한다.
패널이 펼쳐졌다 접히며 폭이 바뀌면 첫 자식 기준으로 나머지가 밀린다.

- 앱 전체 수평 `RadioGroup` 13개에 `baselineAligned="false"`

## App 모드에서 Tesla API 호출

`refreshToken` 옵저버가 `shareMode` 를 보지 않아 App 모드에서도 토큰 갱신과 차량 조회를 했다.
`등록된 차량이 없습니다` 토스트가 뜨는 원인.

- `getAccessTokenAndVehicles`: `shareMode != "api"` 면 반환
- api 로 전환할 때 조회를 트리거
- `TokenWorker.startBackgroundWork`: App 모드면 예약하지 않고 기존 예약도 취소

## 검증

에뮬레이터(Android 15) 디버그·릴리스(R8) 빌드로 확인.

- 탭 왕복 4회에서 다이얼로그 0건, 라디오 상태 유지
- 공개 다이얼로그 뒤 라디오 `비활성화` 유지, 거부 후 재시도 시 공개 재등장
- OS 접근성 ON 상태에서 허용 시 이동 없이 활성화
- 패널 펼침/접힘 3회 반복에도 라디오 3개 y 좌표 동일
- ktlint, 유닛테스트, 릴리스 빌드 통과

비활성화 다이얼로그의 새 문구와 버튼 배치는 실기 확인이 남았다.
