### PR TITLE
fix(a11y): 안내를 닫은 사용자에게 자동 표시되지 않도록

### DIFF
--- a/app/src/main/kotlin/me/zipi/navitotesla/util/AccessibilityDisclosure.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/AccessibilityDisclosure.kt
@@ -76,6 +76,7 @@ object AccessibilityDisclosure {
     /** 최초 실행 또는 업데이트 후 첫 실행에 한 번만 자동으로 띄운다. */
     suspend fun shouldAutoShow(context: Context): Boolean {
         if (isActiveAsync(context)) return false
+        if (isGuideDismissedSync()) return false
         if (withContext(Dispatchers.IO) { isNaviInstalled(context) }) {
             if (PreferencesUtil.getBoolean(KEY_DECLINED, false)) return false
             return PreferencesUtil.getLong(KEY_LAST_SHOWN_VERSION, 0L) < BuildConfig.VERSION_CODE


### PR DESCRIPTION
안내 카드를 `✕` 로 닫은 사용자에게 다음 업데이트에서 안내 다이얼로그가 자동으로 뜨던 문제를 고친다.

`shouldAutoShow` 가 닫힘 상태를 보지 않아, 카드는 숨겨진 채 다이얼로그만 표시됐다.
