### PR TITLE
refactor: 법정동 포함(withLocalName) 로직 제거 및 TMAP 좌표 버그 수정

### DIFF
--- a/app/src/main/kotlin/me/zipi/navitotesla/model/KakaoMap.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/model/KakaoMap.kt
@@ -15,27 +15,7 @@ class KakaoMap {
         val longitude: String? = null,
         @SerializedName("y")
         val latitude: String? = null,
-    ) {
-        fun getRoadAddressName(withLocalName: Boolean): String {
-            // 시도 구군구 읍동면리 (산) 123(-2)
-            var address = roadAddressName ?: ""
-            val match = pattern.find(addressName ?: "")
-            if (match != null && withLocalName) {
-                val lowerAddrName = match.groupValues[1]
-                if (lowerAddrName.isNotEmpty()) {
-                    val lastChar = lowerAddrName.last().toString()
-                    if (lastChar == "동" || lastChar == "로" || lastChar == "가") {
-                        address += " ($lowerAddrName)"
-                    }
-                }
-            }
-            return address
-        }
-
-        companion object {
-            private val pattern = Regex("([^\\s]+)\\s(?:산\\s)?\\d+(?:-\\d)?$")
-        }
-    }
+    )
 
     data class Response<T>(
         var documents: List<T> = listOf(),

--- a/app/src/main/kotlin/me/zipi/navitotesla/model/NaverFusionSearch.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/model/NaverFusionSearch.kt
@@ -14,12 +14,5 @@ class NaverFusionSearch {
         var roadAddress: String? = null,
         var latitude: Double? = null,
         var longitude: Double? = null,
-    ) {
-        fun getRoadAddressName(withLocalName: Boolean): String {
-            if (!withLocalName || roadAddress == null) return roadAddress ?: ""
-            val parts = address?.split(" ")
-            val localName = parts?.getOrNull(parts.size - 2)
-            return if (localName != null) "$roadAddress ($localName)" else roadAddress ?: ""
-        }
-    }
+    )
 }

--- a/app/src/main/kotlin/me/zipi/navitotesla/model/NaverMap.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/model/NaverMap.kt
@@ -25,13 +25,5 @@ class NaverMap {
 
         val latitude: String
             get() = mapy?.toLongOrNull()?.let { (it / 10_000_000.0).toString() } ?: ""
-
-        fun getRoadAddressName(withLocalName: Boolean): String {
-            if (!withLocalName || roadAddress == null) return roadAddress ?: ""
-            // address에서 동/읍/면 이름 추출 (끝에서 두 번째 구성요소)
-            val parts = address?.split(" ")
-            val localName = parts?.getOrNull(parts.size - 2)
-            return if (localName != null) "$roadAddress ($localName)" else roadAddress ?: ""
-        }
     }
 }

--- a/app/src/main/kotlin/me/zipi/navitotesla/model/TMap.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/model/TMap.kt
@@ -35,7 +35,7 @@ class TMap {
         @SerializedName("noorLon")
         var longitude: String? = null,
     ) {
-        fun getRoadAddress(withLocalName: Boolean): String {
+        fun getRoadAddress(): String {
             if (roadName.isNullOrEmpty() || firstBuildNo.isNullOrEmpty()) return ""
             val sb = StringBuilder()
             sb.append(upperAddrName)
@@ -43,12 +43,6 @@ class TMap {
             sb.append(" ").append(roadName)
             sb.append(" ").append(firstBuildNo)
             if (!secondBuildNo.isNullOrEmpty() && secondBuildNo != "0") sb.append("-").append(secondBuildNo)
-            if (!lowerAddrName.isNullOrEmpty() && withLocalName) {
-                val lastChar = lowerAddrName!!.last().toString()
-                if (lastChar == "동" || lastChar == "로" || lastChar == "가") {
-                    sb.append(" (").append(lowerAddrName).append(")")
-                }
-            }
             return sb.toString()
         }
 

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/place/RoadNumberMatcher.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/place/RoadNumberMatcher.kt
@@ -28,7 +28,7 @@ class RoadNumberMatcher {
     companion object {
         private val WHITESPACE = Regex("\\s+")
 
-        // PoiFinder.getRoadAddressName(withLocalName=true) 의 "(동이름)" 부가 토큰 제거.
+        // 현행 PoiFinder 는 괄호 토큰 미생성 — 레거시 즐겨찾기·직접 입력 대비로 유지.
         private val PAREN_NOISE = Regex("""\([^)]*\)""")
     }
 }

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/KakaoPoiFinder.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/KakaoPoiFinder.kt
@@ -31,12 +31,11 @@ class KakaoPoiFinder : PoiFinder {
             AnalysisUtil.warn("Kakao api error: " + response.errorBody()?.string().orEmpty())
         }
         response.body()?.let { body ->
-            val withLocalName = RemoteConfigUtil.getBoolean("withLocalName") // 법정동 포함 여부
             body.documents.forEach { place ->
                 poiList.add(
                     Poi(
                         poiName = place.placeName,
-                        roadAddress = place.getRoadAddressName(withLocalName),
+                        roadAddress = place.roadAddressName.orEmpty(),
                         address = place.addressName,
                         longitude = place.longitude,
                         latitude = place.latitude,

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/NaverPoiFinder.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/NaverPoiFinder.kt
@@ -43,12 +43,11 @@ class NaverPoiFinder : PoiFinder {
             AnalysisUtil.warn("naver api error: " + response.errorBody()?.string().orEmpty())
         }
         response.body()?.items?.let { items ->
-            val withLocalName = RemoteConfigUtil.getBoolean("withLocalName")
             items.forEach { place ->
                 poiList.add(
                     Poi(
                         poiName = place.name,
-                        roadAddress = place.getRoadAddressName(withLocalName),
+                        roadAddress = place.roadAddress.orEmpty(),
                         address = place.address,
                         longitude = place.longitude,
                         latitude = place.latitude,
@@ -67,12 +66,11 @@ class NaverPoiFinder : PoiFinder {
             AnalysisUtil.warn("naver fusion search error: " + response.errorBody()?.string().orEmpty())
         }
         response.body()?.items?.let { items ->
-            val withLocalName = RemoteConfigUtil.getBoolean("withLocalName")
             items.forEach { place ->
                 poiList.add(
                     Poi(
                         poiName = place.name,
-                        roadAddress = place.getRoadAddressName(withLocalName),
+                        roadAddress = place.roadAddress.orEmpty(),
                         address = place.address,
                         longitude = place.longitude?.toString(),
                         latitude = place.latitude?.toString(),

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/TMapPoiFinder.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/TMapPoiFinder.kt
@@ -41,8 +41,8 @@ class TMapPoiFinder : PoiFinder {
                         poiName = item.name,
                         roadAddress = item.getRoadAddress(),
                         address = item.address,
-                        longitude = item.latitude,
-                        latitude = item.longitude,
+                        longitude = item.longitude,
+                        latitude = item.latitude,
                     )
 
                 listPoi.add(poi)

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/TMapPoiFinder.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/TMapPoiFinder.kt
@@ -35,12 +35,11 @@ class TMapPoiFinder : PoiFinder {
             AnalysisUtil.warn("Tmap api error: " + response.errorBody()?.string().orEmpty())
         }
         if (response.isSuccessful && response.body()?.searchPoiInfo != null) {
-            val withLocalName = RemoteConfigUtil.getBoolean("withLocalName") // 법정동 포함 여부
             for (item in response.body()!!.searchPoiInfo!!.pois.poi) {
                 val poi =
                     Poi(
                         poiName = item.name,
-                        roadAddress = item.getRoadAddress(withLocalName),
+                        roadAddress = item.getRoadAddress(),
                         address = item.address,
                         longitude = item.latitude,
                         latitude = item.longitude,

--- a/app/src/test/kotlin/me/zipi/navitotesla/service/place/RoadNumberMatcherTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/service/place/RoadNumberMatcherTest.kt
@@ -207,7 +207,7 @@ class RoadNumberMatcherTest {
         )
     }
 
-    // === 괄호 부가 토큰 정규화 (PoiFinder withLocalName 결과) ===
+    // === 괄호 부가 토큰 정규화 (레거시 즐겨찾기·사용자 입력) ===
 
     @Test
     fun `괄호 동이름 부가 토큰은 정규화로 제거됨`() {


### PR DESCRIPTION
## withLocalName 제거

법정동 접미사(`(삼성동)`) 로직 제거. Remote Config `withLocalName` 이 `false` 로 고정되어 동작하지 않던 코드이고, 접미사 자체가 불필요. 현재 동작 변화 없음.

- 4개 모델(`KakaoMap`, `NaverMap`, `NaverFusionSearch`, `TMap`)의 접미사 분기와 Kakao 전용 정규식 제거
- 3개 PoiFinder 의 RC 읽기 제거
- 래퍼만 남은 `getRoadAddressName()` 삭제, finder 에서 프로퍼티 직접 사용. TMAP 은 주소를 조립하므로 `getRoadAddress()` 유지
- `RoadNumberMatcher.PAREN_NOISE` 는 유지 — 즐겨찾기·사용자 직접 입력 방어용

RC 파라미터는 콘솔에 남겨둠. 구버전 앱이 읽으므로 배포가 퍼진 뒤 삭제.

## TMAP 좌표 교차 대입 수정

위경도가 서로 바뀌어 대입되던 버그.

```
-  longitude = item.latitude,
-  latitude = item.longitude,
+  longitude = item.longitude,
+  latitude = item.latitude,
```

TMAP 목적지를 GPS 모드로 전송할 때 좌표가 뒤바뀜. Room 저장 좌표도 동일. Kakao/Naver 는 영향 없음.

## 검증

`:app:ktlintCheck :app:testPlaystoreDebugUnitTest` 통과.

`listPoiAddress` 에 API 주입 지점이 없어 좌표 매핑 단위 테스트는 미포함. 실기기 확인 필요.
