### PR TITLE
fix(naver): fusion-search 토큰 교환 적용 및 실패 시 공식 API 폴백

### DIFF
--- a/app/src/main/kotlin/me/zipi/navitotesla/api/NaverFusionSearchApi.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/api/NaverFusionSearchApi.kt
@@ -2,12 +2,24 @@ package me.zipi.navitotesla.api
 
 import me.zipi.navitotesla.model.NaverFusionSearch
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.POST
 import retrofit2.http.Query
 
 interface NaverFusionSearchApi {
+    @POST("/v1/auth/token")
+    suspend fun issueAccessToken(
+        @Header("Cookie") cookie: String,
+        @Body body: NaverFusionSearch.TokenRequest,
+    ): Response<NaverFusionSearch.TokenResponse>
+
+    /** accessToken 은 쿠키를 proof 로 검증하므로 검색 요청에도 쿠키를 함께 보내야 함. */
     @GET("/v1/fusion-search/all")
     suspend fun search(
+        @Header("Cookie") cookie: String,
+        @Header("x-maps-mobileweb-token") accessToken: String,
         @Query("query") query: String,
         @Query("siteSort") siteSort: String = "relativity",
         @Query("petrolType") petrolType: String = "all",

--- a/app/src/main/kotlin/me/zipi/navitotesla/model/NaverFusionSearch.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/model/NaverFusionSearch.kt
@@ -1,6 +1,14 @@
 package me.zipi.navitotesla.model
 
 class NaverFusionSearch {
+    data class TokenRequest(
+        val grantType: String,
+    )
+
+    data class TokenResponse(
+        var accessToken: String? = null,
+    )
+
     data class Response(
         var totalCount: Int = 0,
         var items: List<Place>? = null,

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/NaverMobileWebTokenProvider.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/NaverMobileWebTokenProvider.kt
@@ -1,0 +1,96 @@
+package me.zipi.navitotesla.service.poifinder
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import me.zipi.navitotesla.api.NaverFusionSearchApi
+import me.zipi.navitotesla.model.NaverFusionSearch
+import me.zipi.navitotesla.util.AnalysisUtil
+import me.zipi.navitotesla.util.ResponseCloser
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.util.concurrent.TimeUnit
+
+/**
+ * fusion-search 전용 2단 토큰 취득. m.map.naver.com 쿠키를 proof 로 accessToken 을 발급받음.
+ * 인증이 빠지면 오류가 아니라 조용히 빈 결과(발급은 201 + 빈 본문, 검색은 200 + totalCount 0)가 돌아옴.
+ */
+object NaverMobileWebTokenProvider {
+    data class Credentials(
+        val cookieHeader: String,
+        val accessToken: String,
+    )
+
+    private const val COOKIE_NAME = "nmap_mobileweb_token"
+    private const val COOKIE_ENDPOINT = "https://m.map.naver.com/"
+    private const val GRANT_TYPE = "mobile-web"
+
+    // 쿠키 수명 24h. 경계 실패를 피해 절반만 재사용.
+    private const val COOKIE_REUSE_MS = 12L * 60L * 60L * 1000L
+
+    // CookieJar 미지정(NO_COOKIES) — 쿠키 자동 저장·전송 없이 Set-Cookie 만 직접 읽음.
+    private val client =
+        OkHttpClient
+            .Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(10, TimeUnit.SECONDS)
+            .build()
+
+    @Volatile
+    private var cookie: String? = null
+
+    @Volatile
+    private var cookieIssuedAt = 0L
+
+    /** accessToken 은 수명이 30초라 캐시하지 않고 호출마다 발급. 실패 시 null. */
+    suspend fun credentials(api: NaverFusionSearchApi): Credentials? {
+        val proof = cookie() ?: return null
+        val cookieHeader = "$COOKIE_NAME=$proof"
+        val response =
+            try {
+                api.issueAccessToken(cookieHeader, NaverFusionSearch.TokenRequest(GRANT_TYPE))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                AnalysisUtil.recordException(e)
+                return null
+            }
+        val token = response.body()?.accessToken?.takeIf { it.isNotEmpty() }
+        ResponseCloser.closeAll(response)
+        if (token == null) {
+            AnalysisUtil.warn("naver fusion token issue failed: ${response.code()}")
+            cookie = null
+            return null
+        }
+        return Credentials(cookieHeader, token)
+    }
+
+    private suspend fun cookie(): String? {
+        cookie?.takeIf { System.currentTimeMillis() - cookieIssuedAt < COOKIE_REUSE_MS }?.let { return it }
+        return withContext(Dispatchers.IO) {
+            try {
+                client.newCall(Request.Builder().url(COOKIE_ENDPOINT).head().build()).execute().use { res ->
+                    val issued =
+                        res
+                            .headers("Set-Cookie")
+                            .firstOrNull { it.startsWith("$COOKIE_NAME=") }
+                            ?.substringAfter("=")
+                            ?.substringBefore(";")
+                            ?.takeIf { it.isNotEmpty() }
+                    if (issued == null) {
+                        AnalysisUtil.warn("naver mobileweb cookie not issued: ${res.code}")
+                    } else {
+                        cookie = issued
+                        cookieIssuedAt = System.currentTimeMillis()
+                    }
+                    issued
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                AnalysisUtil.recordException(e)
+                null
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/NaverPoiFinder.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/NaverPoiFinder.kt
@@ -29,11 +29,9 @@ class NaverPoiFinder : PoiFinder {
     @Throws(IOException::class)
     override suspend fun listPoiAddress(poiName: String): List<Poi> {
         val ratio = RemoteConfigUtil.getString("naverApiRatio").toIntOrNull() ?: 100
-        return if (Random.nextInt(100) < ratio) {
-            listPoiAddressViaOpenApi(poiName)
-        } else {
-            listPoiAddressViaFusionSearch(poiName)
-        }
+        if (Random.nextInt(100) < ratio) return listPoiAddressViaOpenApi(poiName)
+        // fusion 은 비공개 API 라 토큰 스펙 변경으로 조용히 빈 결과가 될 수 있음 → 공식 API 로 폴백.
+        return listPoiAddressViaFusionSearch(poiName).ifEmpty { listPoiAddressViaOpenApi(poiName) }
     }
 
     private suspend fun listPoiAddressViaOpenApi(poiName: String): List<Poi> {
@@ -61,7 +59,8 @@ class NaverPoiFinder : PoiFinder {
 
     private suspend fun listPoiAddressViaFusionSearch(poiName: String): List<Poi> {
         val poiList = mutableListOf<Poi>()
-        val response = naverFusionSearchApi.search(poiName)
+        val credentials = NaverMobileWebTokenProvider.credentials(naverFusionSearchApi) ?: return poiList
+        val response = naverFusionSearchApi.search(credentials.cookieHeader, credentials.accessToken, poiName)
         if (!response.isSuccessful || response.body() == null) {
             AnalysisUtil.warn("naver fusion search error: " + response.errorBody()?.string().orEmpty())
         }


### PR DESCRIPTION
## 문제

`svc-api.map.naver.com/v1/fusion-search/all` 이 인증을 요구하도록 바뀌어 모든 쿼리에 빈 결과를 반환. 오류가 아니라 HTTP 200 + `totalCount: 0, searchType: "unknown"` 이라 드러나지 않았음.

`naverApiRatio=80` 이므로 네이버내비 목적지의 20% 가 주소를 받지 못하는 상태.

## 해결

2단 토큰 취득 적용.

```
1) HEAD https://m.map.naver.com/                    → nmap_mobileweb_token 쿠키 (수명 24h)
2) POST /v1/auth/token  {"grantType":"mobile-web"}  + Cookie  → accessToken (수명 30초)
3) GET  /v1/fusion-search/all?…                     + Cookie + x-maps-mobileweb-token
```

accessToken 은 쿠키를 proof 로 검증하므로 검색 요청에도 쿠키를 함께 보내야 함.

- 쿠키는 12시간만 재사용(만료 경계 회피), accessToken 은 수명이 짧아 호출마다 발급
- 토큰 발급 실패 시 쿠키를 폐기해 다음 호출에서 재발급
- OkHttp CookieJar 미지정(NO_COOKIES) — 쿠키 자동 저장·전송 없이 필요한 하나만 명시적으로 전달. Referer 는 사용하지 않음

## 폴백

fusion 은 비공개 API 라 다시 막힐 수 있으므로, 토큰 발급 실패와 빈 결과를 모두 공식 지역검색 API 로 흡수.

```kotlin
return listPoiAddressViaFusionSearch(poiName).ifEmpty { listPoiAddressViaOpenApi(poiName) }
```

## 검증

실제 API 로 코엑스·정부세종청사·포항역 확인 (`totalCount` 38153 / 380 / 7944, items 10). 응답 필드가 기존 `NaverFusionSearch.Place` 와 일치해 모델 변경 없음.

`:app:ktlintCheck :app:testPlaystoreDebugUnitTest` 통과.

`NaverPoiFinder` 가 Retrofit 인스턴스를 직접 생성해 주입 지점이 없어 단위 테스트는 미포함.
