### PR TITLE
fix(kakao): 안전운전 오판으로 전송이 차단되던 문제 수정

### DIFF
--- a/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/AppRepository.kt
@@ -52,7 +52,7 @@ class AppRepository private constructor(
                         }.apply {
                             level = HttpLoggingInterceptor.Level.BASIC
                         },
-                    ).addInterceptor(HttpRetryInterceptor(20))
+                    ).addInterceptor(HttpRetryInterceptor(5))
                     .build(),
             ).build()
             .create()
@@ -83,7 +83,7 @@ class AppRepository private constructor(
                         }.apply {
                             level = HttpLoggingInterceptor.Level.BASIC
                         },
-                    ).addInterceptor(HttpRetryInterceptor(20))
+                    ).addInterceptor(HttpRetryInterceptor(5))
                     .build(),
             ).build()
             .create()

--- a/app/src/main/kotlin/me/zipi/navitotesla/exception/IgnorePoiException.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/exception/IgnorePoiException.kt
@@ -1,6 +1,8 @@
 package me.zipi.navitotesla.exception
 
-@Suppress("unused")
+import me.zipi.navitotesla.service.poifinder.IgnoreReason
+
 class IgnorePoiException(
     packageName: String,
-) : RuntimeException(packageName)
+    val reason: IgnoreReason,
+) : RuntimeException("$packageName: $reason")

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/NaviToTeslaService.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/NaviToTeslaService.kt
@@ -215,7 +215,7 @@ class NaviToTeslaService(
         eventParam.putString("package", packageName)
         val poiFinder = PoiFinderFactory.getPoiFinder(packageName)
         val poiName = poiFinder.parseDestination(notificationText ?: "")
-        // 단축평가로 사유가 뭉개지지 않도록 ignoreReason 을 먼저 확정한다.
+        // 단축평가로 사유가 뭉개지지 않도록 먼저 확정.
         val ignoreReason =
             poiFinder.ignoreReason(notificationTitle ?: "", notificationText ?: "")
                 ?: IgnoreReason.EMPTY_DESTINATION.takeIf { poiName.isEmpty() }

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/NaviToTeslaService.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/NaviToTeslaService.kt
@@ -18,6 +18,7 @@ import me.zipi.navitotesla.model.TeslaRefreshTokenRequest
 import me.zipi.navitotesla.model.Token
 import me.zipi.navitotesla.model.Vehicle
 import me.zipi.navitotesla.service.place.DestinationAddressResolver
+import me.zipi.navitotesla.service.poifinder.IgnoreReason
 import me.zipi.navitotesla.service.poifinder.PoiFinderFactory
 import me.zipi.navitotesla.service.share.SendPlanner
 import me.zipi.navitotesla.service.share.TeslaShareByApi
@@ -121,7 +122,8 @@ class NaviToTeslaService(
                 text = context.getString(R.string.sendDestinationFail) + "\n" + context.getString(R.string.unsupportedNavi),
                 level = AnalysisUtil.ToastLevel.WARN,
             )
-        } catch (_: IgnorePoiException) {
+        } catch (e: IgnorePoiException) {
+            eventParam.putString("reason", e.reason.name)
             AnalysisUtil.logEvent("ignore_address", eventParam)
         } catch (e: ForbiddenException) {
             makeToast(
@@ -213,14 +215,15 @@ class NaviToTeslaService(
         eventParam.putString("package", packageName)
         val poiFinder = PoiFinderFactory.getPoiFinder(packageName)
         val poiName = poiFinder.parseDestination(notificationText ?: "")
-        if (poiName.isEmpty() ||
-            poiFinder.isIgnore(
-                notificationTitle ?: "",
-                notificationText ?: "",
-            )
-        ) {
+        // 단축평가로 사유가 뭉개지지 않도록 ignoreReason 을 먼저 확정한다.
+        val ignoreReason =
+            poiFinder.ignoreReason(notificationTitle ?: "", notificationText ?: "")
+                ?: IgnoreReason.EMPTY_DESTINATION.takeIf { poiName.isEmpty() }
+        if (ignoreReason != null) {
+            AnalysisUtil.log("ignore poi ~ pkg: $packageName reason: $ignoreReason title: $notificationTitle")
+            eventParam.putString("reason", ignoreReason.name)
             AnalysisUtil.logEvent("address_ignore_or_not_found", eventParam)
-            throw IgnorePoiException(packageName)
+            throw IgnorePoiException(packageName, ignoreReason)
         }
         val poiAddressEntity = appRepository.getPoiSync(poiName, packageName)
         val poi: Poi

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/IgnoreReason.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/IgnoreReason.kt
@@ -1,0 +1,25 @@
+package me.zipi.navitotesla.service.poifinder
+
+/** 전송을 건너뛴 사유. 무성 실패의 원인을 로그·이벤트에서 구분하기 위함. */
+enum class IgnoreReason {
+    /** 알림 제목이 안전운전/안심주행 — 목적지 없는 주행 모드. */
+    SAFE_TITLE,
+
+    /** 알림 제목이 길안내 화이트리스트 밖. */
+    TITLE_MISMATCH,
+
+    /** 알림 본문이 안내 시작 문구가 아님. */
+    TEXT_MISMATCH,
+
+    /** 접근성으로 캡처한 목적지가 없음. */
+    NO_CAPTURE,
+
+    /** 캡처한 목적지가 너무 오래됨. */
+    TTL_EXPIRED,
+
+    /** 화면 판정 결과가 안전운전. */
+    SAFE_DRIVE,
+
+    /** 목적지 문자열을 뽑지 못함. */
+    EMPTY_DESTINATION,
+}

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/IgnoreReason.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/IgnoreReason.kt
@@ -1,25 +1,12 @@
 package me.zipi.navitotesla.service.poifinder
 
-/** 전송을 건너뛴 사유. 무성 실패의 원인을 로그·이벤트에서 구분하기 위함. */
+/** 전송을 건너뛴 사유. 무성 실패 원인을 로그·이벤트에서 구분하기 위함. */
 enum class IgnoreReason {
-    /** 알림 제목이 안전운전/안심주행 — 목적지 없는 주행 모드. */
     SAFE_TITLE,
-
-    /** 알림 제목이 길안내 화이트리스트 밖. */
     TITLE_MISMATCH,
-
-    /** 알림 본문이 안내 시작 문구가 아님. */
     TEXT_MISMATCH,
-
-    /** 접근성으로 캡처한 목적지가 없음. */
     NO_CAPTURE,
-
-    /** 캡처한 목적지가 너무 오래됨. */
     TTL_EXPIRED,
-
-    /** 화면 판정 결과가 안전운전. */
     SAFE_DRIVE,
-
-    /** 목적지 문자열을 뽑지 못함. */
     EMPTY_DESTINATION,
 }

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/KakaoPoiFinder.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/KakaoPoiFinder.kt
@@ -47,15 +47,18 @@ class KakaoPoiFinder : PoiFinder {
         return poiList
     }
 
-    override fun isIgnore(
+    override fun ignoreReason(
         notificationTitle: String,
         notificationText: String,
-    ): Boolean {
-        if (notificationTitle !in GUIDANCE_TITLES) return true
-        if (notificationText.contains(LEGACY_DESTINATION_PREFIX)) return false
-        if (destination.isNullOrEmpty()) return true
-        if (System.currentTimeMillis() - savedTime > DESTINATION_TTL_MS) return true
-        return driveModeProvider?.invoke() == NaviDriveMode.SAFE_DRIVE
+    ): IgnoreReason? {
+        // 안전운전 모드는 알림 제목으로 확정 구분된다 — 화면 판정보다 우선.
+        if (notificationTitle in SAFE_TITLES) return IgnoreReason.SAFE_TITLE
+        if (notificationTitle !in GUIDANCE_TITLES) return IgnoreReason.TITLE_MISMATCH
+        if (notificationText.contains(LEGACY_DESTINATION_PREFIX)) return null
+        if (destination.isNullOrEmpty()) return IgnoreReason.NO_CAPTURE
+        if (System.currentTimeMillis() - savedTime > DESTINATION_TTL_MS) return IgnoreReason.TTL_EXPIRED
+        if (driveModeProvider?.invoke() == NaviDriveMode.SAFE_DRIVE) return IgnoreReason.SAFE_DRIVE
+        return null
     }
 
     override fun consumeCapturedDestination() = clearDestination()
@@ -63,8 +66,11 @@ class KakaoPoiFinder : PoiFinder {
     companion object {
         private const val LEGACY_DESTINATION_PREFIX = "목적지 : "
 
-        /** 보험 ON 이면 제목이 바뀐다. */
+        /** 보험 ON 이면 제목이 바뀐다. (noti_drive_title / noti_drive_insurance_title) */
         private val GUIDANCE_TITLES = setOf("길안내 주행 중", "보험을 켜고 길안내 주행 중")
+
+        /** 목적지 없는 주행 모드. (noti_safety_drive_title / noti_safety_drive_insurance_title) */
+        private val SAFE_TITLES = setOf("안전운전 주행 중", "보험을 켜고 안전운전 주행 중")
 
         private const val DESTINATION_TTL_MS = 60_000L
 

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/KakaoPoiFinder.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/KakaoPoiFinder.kt
@@ -51,7 +51,7 @@ class KakaoPoiFinder : PoiFinder {
         notificationTitle: String,
         notificationText: String,
     ): IgnoreReason? {
-        // 안전운전 모드는 알림 제목으로 확정 구분된다 — 화면 판정보다 우선.
+        // 안전운전은 알림 제목으로 확정 구분 — 화면 판정보다 우선.
         if (notificationTitle in SAFE_TITLES) return IgnoreReason.SAFE_TITLE
         if (notificationTitle !in GUIDANCE_TITLES) return IgnoreReason.TITLE_MISMATCH
         if (notificationText.contains(LEGACY_DESTINATION_PREFIX)) return null
@@ -66,10 +66,10 @@ class KakaoPoiFinder : PoiFinder {
     companion object {
         private const val LEGACY_DESTINATION_PREFIX = "목적지 : "
 
-        /** 보험 ON 이면 제목이 바뀐다. (noti_drive_title / noti_drive_insurance_title) */
+        /** 보험 ON 이면 제목이 바뀐다. */
         private val GUIDANCE_TITLES = setOf("길안내 주행 중", "보험을 켜고 길안내 주행 중")
 
-        /** 목적지 없는 주행 모드. (noti_safety_drive_title / noti_safety_drive_insurance_title) */
+        /** 목적지 없는 주행 모드. */
         private val SAFE_TITLES = setOf("안전운전 주행 중", "보험을 켜고 안전운전 주행 중")
 
         private const val DESTINATION_TTL_MS = 60_000L
@@ -123,7 +123,7 @@ class KakaoPoiFinder : PoiFinder {
                                         ).build()
                                 chain.proceed(request)
                             },
-                        ).addInterceptor(HttpRetryInterceptor(10))
+                        ).addInterceptor(HttpRetryInterceptor(3))
                         .build(),
                 ).build()
                 .create(KakaoMapApi::class.java)

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/NaverPoiFinder.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/NaverPoiFinder.kt
@@ -101,7 +101,7 @@ class NaverPoiFinder : PoiFinder {
                 .Builder()
                 .connectTimeout(120, TimeUnit.SECONDS)
                 .readTimeout(120, TimeUnit.SECONDS)
-                .addInterceptor(HttpRetryInterceptor(10))
+                .addInterceptor(HttpRetryInterceptor(3))
                 .build()
 
         private val naverMapApi =

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/NaverPoiFinder.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/NaverPoiFinder.kt
@@ -81,15 +81,16 @@ class NaverPoiFinder : PoiFinder {
         return poiList
     }
 
-    override fun isIgnore(
+    override fun ignoreReason(
         notificationTitle: String,
         notificationText: String,
-    ): Boolean {
+    ): IgnoreReason? {
         // 안내가 시작될 경우 도착지를 이용하여 전송한다. 목적지가 입력된지 특정 시간 내에만 동작한다.
-        if (notificationText != GUIDANCE_TEXT) return true
-        if (destination.isNullOrEmpty()) return true
-        if (System.currentTimeMillis() - savedTime > DESTINATION_TTL_MS) return true
-        return driveModeProvider?.invoke() == NaviDriveMode.SAFE_DRIVE
+        if (notificationText != GUIDANCE_TEXT) return IgnoreReason.TEXT_MISMATCH
+        if (destination.isNullOrEmpty()) return IgnoreReason.NO_CAPTURE
+        if (System.currentTimeMillis() - savedTime > DESTINATION_TTL_MS) return IgnoreReason.TTL_EXPIRED
+        if (driveModeProvider?.invoke() == NaviDriveMode.SAFE_DRIVE) return IgnoreReason.SAFE_DRIVE
+        return null
     }
 
     override fun consumeCapturedDestination() = clearDestination()

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/PoiFinder.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/PoiFinder.kt
@@ -26,10 +26,16 @@ interface PoiFinder {
     @Throws(IOException::class)
     suspend fun listPoiAddress(poiName: String): List<Poi>
 
+    /** null 이면 처리, 그 외에는 건너뛴 사유. */
+    fun ignoreReason(
+        notificationTitle: String,
+        notificationText: String,
+    ): IgnoreReason?
+
     fun isIgnore(
         notificationTitle: String,
         notificationText: String,
-    ): Boolean
+    ): Boolean = ignoreReason(notificationTitle, notificationText) != null
 
     /** 접근성으로 모아 둔 목적지를 버린다. */
     fun consumeCapturedDestination() {}

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/TMapPoiFinder.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/TMapPoiFinder.kt
@@ -92,7 +92,7 @@ class TMapPoiFinder : PoiFinder {
                                         ).build()
                                 chain.proceed(request)
                             },
-                        ).addInterceptor(HttpRetryInterceptor(10))
+                        ).addInterceptor(HttpRetryInterceptor(3))
                         .build(),
                 ).build()
                 .create(TMapApi::class.java)

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/TMapPoiFinder.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/poifinder/TMapPoiFinder.kt
@@ -52,10 +52,15 @@ class TMapPoiFinder : PoiFinder {
         return listPoi
     }
 
-    override fun isIgnore(
+    override fun ignoreReason(
         notificationTitle: String,
         notificationText: String,
-    ): Boolean = notificationText == "안심주행" || notificationTitle != "경로주행"
+    ): IgnoreReason? =
+        when {
+            notificationText == "안심주행" -> IgnoreReason.SAFE_TITLE
+            notificationTitle != "경로주행" -> IgnoreReason.TITLE_MISMATCH
+            else -> null
+        }
 
     companion object {
         private val tMapApi =

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/reader/KakaoDestinationReader.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/reader/KakaoDestinationReader.kt
@@ -72,9 +72,7 @@ class KakaoDestinationReader : DestinationReader {
         const val ROUTE_SUMMARY_ID = "com.locnall.KimGiSa:id/route_result_trip"
         val ROUTE_ANCHOR = Regex("^출발\\s+.+?,\\s*도착\\s+(.+)$")
 
-        // 449 리소스 실측으로 검증한 문구만. 부분문자열 매칭이라 길안내 화면 문구와 겹치면 안 된다.
-        // "교통상황" 은 재탐색 토스트("교통상황이 변하여 …")와 겹쳐 길안내를 안전운전으로 오판시켰다.
-        // "신호등 정보" 와 "경로 새로고침" 은 449 리소스에 없는 죽은 마커였다.
+        // 부분문자열 매칭이라 길안내 화면 문구와 겹치면 안 됨 — "교통상황" 은 재탐색 토스트와 충돌.
         val SAFE_MARKERS = listOf("안전운전 종료")
         val GUIDANCE_MARKERS = listOf("전체경로", "남음")
     }

--- a/app/src/main/kotlin/me/zipi/navitotesla/service/reader/KakaoDestinationReader.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/service/reader/KakaoDestinationReader.kt
@@ -72,7 +72,10 @@ class KakaoDestinationReader : DestinationReader {
         const val ROUTE_SUMMARY_ID = "com.locnall.KimGiSa:id/route_result_trip"
         val ROUTE_ANCHOR = Regex("^출발\\s+.+?,\\s*도착\\s+(.+)$")
 
-        val SAFE_MARKERS = listOf("안전운전 종료", "교통상황", "신호등 정보")
-        val GUIDANCE_MARKERS = listOf("전체경로", "경로 새로고침", "남음")
+        // 449 리소스 실측으로 검증한 문구만. 부분문자열 매칭이라 길안내 화면 문구와 겹치면 안 된다.
+        // "교통상황" 은 재탐색 토스트("교통상황이 변하여 …")와 겹쳐 길안내를 안전운전으로 오판시켰다.
+        // "신호등 정보" 와 "경로 새로고침" 은 449 리소스에 없는 죽은 마커였다.
+        val SAFE_MARKERS = listOf("안전운전 종료")
+        val GUIDANCE_MARKERS = listOf("전체경로", "남음")
     }
 }

--- a/app/src/main/kotlin/me/zipi/navitotesla/ui/favorite/PoiAddressRecyclerAdapter.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/ui/favorite/PoiAddressRecyclerAdapter.kt
@@ -81,11 +81,14 @@ class PoiAddressRecyclerAdapter(
         }
 
         override fun onClick(view: View) {
+            // 목록 갱신 중 탭하면 수신측 list.get(-1) 에서 크래시.
+            val position = bindingAdapterPosition
+            if (position == RecyclerView.NO_POSITION) return
             listenerRef.get()?.let {
                 if (view.id == shareButton.id) {
-                    it.onShareClick(bindingAdapterPosition)
+                    it.onShareClick(position)
                 } else {
-                    it.onClick(bindingAdapterPosition)
+                    it.onClick(position)
                 }
             }
         }

--- a/app/src/main/kotlin/me/zipi/navitotesla/ui/home/HomeFragment.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/ui/home/HomeFragment.kt
@@ -601,8 +601,12 @@ class HomeFragment :
     private fun refreshTokenButtonEnabled() {
         if (!isAdded || view == null) return
         val useApi = binding.radioGroupShareMode.checkedButtonId == binding.radioUsingTeslaApi.id
-        val hasToken = PreferencesUtil.loadTokenSync() != null
-        binding.btnTokenClear.isEnabled = useApi && hasToken
+        // loadTokenSync 는 초기화 대기로 메인을 막을 수 있음.
+        lifecycleScope.launch {
+            val hasToken = PreferencesUtil.loadToken() != null
+            if (!isAdded || view == null) return@launch
+            binding.btnTokenClear.isEnabled = useApi && hasToken
+        }
     }
 
     private fun overlayPermissionGrantedCheck() {

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/AppUpdaterUtil.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/AppUpdaterUtil.kt
@@ -42,7 +42,7 @@ object AppUpdaterUtil {
                     .Builder()
                     .connectTimeout(60, TimeUnit.SECONDS)
                     .readTimeout(60, TimeUnit.SECONDS)
-                    .addInterceptor(HttpRetryInterceptor(10))
+                    .addInterceptor(HttpRetryInterceptor(3))
                     .build(),
             ).build()
             .create(GithubApi::class.java)

--- a/app/src/main/kotlin/me/zipi/navitotesla/util/HttpRetryInterceptor.kt
+++ b/app/src/main/kotlin/me/zipi/navitotesla/util/HttpRetryInterceptor.kt
@@ -10,13 +10,19 @@ import java.util.Locale
 class HttpRetryInterceptor(
     private val maxRetryCount: Int = 0,
 ) : Interceptor {
+    private companion object {
+        const val MAX_SLEEP_MS = 2_000L
+
+        // 시간이 지나면 풀리는 4xx. 나머지 4xx 는 재시도로 결과가 바뀌지 않음.
+        val RETRYABLE_4XX = setOf(408, 425, 429)
+    }
+
     private fun sleep(
         retry: Int,
         chain: Interceptor.Chain,
     ) {
         try {
-            var sleep = retry * retry * 100L / 2
-            sleep = if (sleep > 3000) 3000 else sleep
+            val sleep = if (retry <= 0) 0L else (300L shl (retry - 1)).coerceAtMost(MAX_SLEEP_MS)
             if (sleep > 0) {
                 Thread.sleep(sleep)
                 AnalysisUtil.log(
@@ -50,7 +56,7 @@ class HttpRetryInterceptor(
             }
             if (isSuccess) {
                 break
-            } else if (response != null && response.code >= 400 && response.code <= 405) {
+            } else if (response != null && response.code in 400..499 && response.code !in RETRYABLE_4XX) {
                 AnalysisUtil.warn("Http call 4xx error!: " + response.code)
                 break
             } else if (retry >= maxRetryCount) {

--- a/app/src/test/kotlin/me/zipi/navitotesla/service/poifinder/KakaoPoiFinderTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/service/poifinder/KakaoPoiFinderTest.kt
@@ -155,4 +155,35 @@ class KakaoPoiFinderTest {
         assertTrue(KakaoPoiFinder.hasLegacyDestination("목적지 : 송파구청"))
         assertFalse(KakaoPoiFinder.hasLegacyDestination("빠르고 즐거운 운전, 카카오내비"))
     }
+
+    // === 무시 사유 (무성 실패 원인 구분) ===
+
+    @Test
+    fun `ignoreReason 안전운전 제목은 SAFE_TITLE`() {
+        KakaoPoiFinder.addDestination("정자역")
+        assertEquals(IgnoreReason.SAFE_TITLE, finder.ignoreReason("안전운전 주행 중", "빠르고 즐거운 운전, 카카오내비"))
+        assertEquals(
+            IgnoreReason.SAFE_TITLE,
+            finder.ignoreReason("보험을 켜고 안전운전 주행 중", "빠르고 즐거운 운전, 카카오내비"),
+        )
+    }
+
+    @Test
+    fun `ignoreReason 화이트리스트 밖 제목은 TITLE_MISMATCH`() {
+        KakaoPoiFinder.addDestination("정자역")
+        assertEquals(IgnoreReason.TITLE_MISMATCH, finder.ignoreReason("길안내 종료 중", "빠르고 즐거운 운전, 카카오내비"))
+        assertEquals(IgnoreReason.TITLE_MISMATCH, finder.ignoreReason("", "빠르고 즐거운 운전, 카카오내비"))
+    }
+
+    @Test
+    fun `ignoreReason 캡처 없으면 NO_CAPTURE`() {
+        assertEquals(IgnoreReason.NO_CAPTURE, finder.ignoreReason("길안내 주행 중", "빠르고 즐거운 운전, 카카오내비"))
+    }
+
+    @Test
+    fun `ignoreReason 정상 경로는 null`() {
+        KakaoPoiFinder.addDestination("정자역")
+        assertEquals(null, finder.ignoreReason("길안내 주행 중", "빠르고 즐거운 운전, 카카오내비"))
+        assertEquals(null, finder.ignoreReason("길안내 주행 중", "목적지 : 송파구청"))
+    }
 }

--- a/app/src/test/kotlin/me/zipi/navitotesla/service/poifinder/TMapPoiFinderTest.kt
+++ b/app/src/test/kotlin/me/zipi/navitotesla/service/poifinder/TMapPoiFinderTest.kt
@@ -52,4 +52,11 @@ class TMapPoiFinderTest {
         assertTrue(finder.isIgnore("일반 알림", "내 위치 > 강남역"))
         assertTrue(finder.isIgnore("", "내 위치 > 강남역"))
     }
+
+    @Test
+    fun `ignoreReason 사유 구분`() {
+        assertEquals(IgnoreReason.SAFE_TITLE, finder.ignoreReason("경로주행", "안심주행"))
+        assertEquals(IgnoreReason.TITLE_MISMATCH, finder.ignoreReason("일반 알림", "내 위치 > 강남역"))
+        assertEquals(null, finder.ignoreReason("경로주행", "내 위치 > 강남역"))
+    }
 }


### PR DESCRIPTION
## 카카오 전송 차단 수정

`SAFE_MARKERS` 의 `"교통상황"` 이 카카오 재탐색 문구(`"교통상황이 변하여 새로운 경로로 안내합니다."`)와 겹쳐, 길안내를 안전운전으로 오판해 전송이 조용히 건너뛰어짐.

- `SAFE_MARKERS` 에서 `"교통상황"` 제거. `"신호등 정보"`·`"경로 새로고침"` 은 카카오 4.49 리소스에 없는 죽은 마커라 함께 제거
- 안전운전은 알림 제목으로 확정 구분되므로 `SAFE_TITLES` 를 최우선 평가

## 무시 사유 계측

제목 불일치·캡처 없음·TTL 만료·주행모드 오판이 한 이벤트로 뭉개져 원인 분해 불가였음.

- `IgnoreReason` 추가. `isIgnore` → `ignoreReason`(기존 호출부 무영향)
- `getPoi` 단축평가 제거로 사유 확정
- 사유를 이벤트·로그 파일에 기록 — 진단 화면에서 확인 가능

## HTTP 재시도

- 중단 범위 `400..405` → `400..499`, 단 `408`·`425`·`429` 는 재시도 유지
- 백오프 `0.3s → 0.6s → 1.2s → 2s`(상한)
- 횟수 축소 — Tesla API 20→5회(최대 6.1초), 나머지 10→3회(최대 2.1초)

## 크래시·블로킹 가드

- `PoiAddressRecyclerAdapter` 가 `NO_POSITION` 을 넘겨 수신측 `list.get(-1)` 크래시 → 콜백 전 차단
- `refreshTokenButtonEnabled()` 의 메인 스레드 `loadTokenSync()` → suspend 버전으로 교체

## 검증

`ktlintCheck` + playstore/nostore 단위 테스트 통과. `ignoreReason` 사유 구분 테스트 추가.
`driveMode()` 는 `AccessibilityNodeInfo` 의존으로 단위 테스트 불가 — 마커는 카카오 4.49 리소스 대조로 확인.
